### PR TITLE
Add structured logging and configurable log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 ## Contributors
 
   - [Dr. Sébastien Mosser](https://mosser.github.io/), Associate Professor, McMaster University
-  - [Nirmal Chaudhari](https://www.linkedin.com/in/nirmal2003/), B.Eng. Student, McMaster University
   - [Cass Braun](https://www.linkedin.com/in/cass-braun/), B.Eng. Student, McMaster University
   - [Andrew Bovbel](https://www.linkedin.com/in/andrewbovbel/), B.Eng. Student, McMaster University
+  - [Nirmal Chaudhari](https://www.linkedin.com/in/nirmal2003/), B.Eng. Student, McMaster University
 
 ## How to contribute?
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -177,6 +177,21 @@
                     "type": "string",
                     "default": "java",
                     "markdownDescription": "**[jar mode only]** Path to the `java` executable used to run the JAR. Defaults to `java` (resolved via `PATH`)."
+                },
+                "jpipe.logLevel": {
+                    "order": 5,
+                    "type": "string",
+                    "enum": ["off", "error", "warn", "info", "debug", "trace"],
+                    "enumDescriptions": [
+                        "No logging.",
+                        "Errors only.",
+                        "Errors and warnings.",
+                        "Errors, warnings, and key lifecycle events (default).",
+                        "Detailed operational info (commands, renders, imports).",
+                        "Everything, including per-cursor and per-completion events."
+                    ],
+                    "default": "info",
+                    "description": "Verbosity of the jPipe log channel (Output > jPipe). The language server log level (Output > jPipe Language Server) is set once at startup and requires a window reload to change."
                 }
             }
         }

--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -4,6 +4,7 @@ import { promisify } from 'node:util';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
+import { JpipeLogger } from '../logger.js';
 
 const execAsync = promisify(exec);
 
@@ -33,8 +34,8 @@ export enum ImageFormat {
 }
 
 export class ImageGenerator {
-    
-    constructor() {}
+
+    constructor(private readonly logger: JpipeLogger) {}
     
     /**
      * Generate an image from the active jpipe file or provided document
@@ -95,13 +96,15 @@ export class ImageGenerator {
                 try {
                     const { stdout } = await execAsync(`which ${cliPath}`, { env: envWithPath() });
                     cliCmd = stdout.trim();
+                    this.logger.debug(`Resolved CLI '${cliPath}' → ${cliCmd}`);
                 } catch {
                     cliCmd = cliPath;
+                    this.logger.debug(`'which ${cliPath}' failed, using bare name`);
                 }
             }
             command = `"${cliCmd}" process ${inputArg} ${modelArg} ${formatArg}`;
         }
-        
+
         if (saveToFile) {
             const outputPath = await this.promptForSaveLocation(document, diagramName, format);
             if (!outputPath) {
@@ -111,15 +114,15 @@ export class ImageGenerator {
             }
             command += ` -o "${outputPath.fsPath}"`;
         }
-        
-        console.log('[jPipe] Executing command:', command);
-        
+
+        this.logger.debug(`Executing: ${command}`);
+
         try {
             const { stdout } = await execAsync(command);
-            console.log('[jPipe] Generated SVG successfully');
+            this.logger.info(`Generated ${format} for '${diagramName}' (${path.basename(document.uri.fsPath)})`);
             return stdout;
         } catch (error: any) {
-            console.error('[jPipe] Error generating SVG:', error);
+            this.logGenerationError(diagramName, error);
             // Preserve stdout/stderr so the preview can still render a best-effort SVG (if any)
             // and show diagnostics inline instead of blanking the whole viewer.
             const e = new Error(`Failed to generate SVG: ${error.message}`) as Error & { stdout?: string; stderr?: string; exitCode?: number };
@@ -182,6 +185,17 @@ export class ImageGenerator {
         }
     }
     
+    private logGenerationError(diagramName: string, error: any): void {
+        const exitCode: number | undefined = typeof error?.code === 'number' ? error.code : undefined;
+        if (exitCode === 1) {
+            this.logger.warn(`Compiler exit 1 (model errors) for '${diagramName}'`);
+        } else if (exitCode === 42) {
+            this.logger.error(`Compiler exit 42 (crash) for '${diagramName}'`);
+        } else {
+            this.logger.error(`Generation failed for '${diagramName}': ${error instanceof Error ? error.message : String(exitCode ?? error)}`);
+        }
+    }
+
     findDiagramName(document: vscode.TextDocument, editor: vscode.TextEditor | undefined): string {
         const lines = document.getText().split('\n');
         const cursorLine = editor?.selection.active.line ?? 0;

--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -125,7 +125,7 @@ export class ImageGenerator {
             this.logGenerationError(diagramName, error);
             // Preserve stdout/stderr so the preview can still render a best-effort SVG (if any)
             // and show diagnostics inline instead of blanking the whole viewer.
-            const e = new Error(`Failed to generate SVG: ${error.message}`) as Error & { stdout?: string; stderr?: string; exitCode?: number };
+            const e = new Error(`Failed to generate ${format}: ${error.message}`) as Error & { stdout?: string; stderr?: string; exitCode?: number };
             e.stdout = typeof error?.stdout === 'string' ? error.stdout : undefined;
             e.stderr = typeof error?.stderr === 'string' ? error.stderr : undefined;
             e.exitCode = typeof error?.code === 'number' ? error.code : undefined;

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import type { LanguageClient } from 'vscode-languageclient/node.js';
 import { ImageGenerator, ImageFormat } from './image-generator.js';
+import type { JpipeLogger } from '../logger.js';
 
 interface DocumentSymbol {
     name: string;
@@ -20,26 +21,29 @@ export class PreviewProvider {
     constructor(
         private readonly imageGenerator: ImageGenerator,
         private readonly languageClient: LanguageClient,
-        context: vscode.ExtensionContext
+        context: vscode.ExtensionContext,
+        private readonly logger: JpipeLogger
     ) {
         this.setupEventListeners(context);
     }
-    
+
     public async openPreview(): Promise<void> {
         const editor = vscode.window.activeTextEditor;
-        
+
         if (!editor || editor.document.languageId !== 'jpipe') {
             vscode.window.showErrorMessage('No active jPipe file');
             return;
         }
-        
+
         if (PreviewProvider.webviewDisposed || !PreviewProvider.webviewPanel) {
             PreviewProvider.webviewPanel = this.createWebviewPanel();
             PreviewProvider.webviewDisposed = false;
+            this.logger.info('Webview panel created');
         } else {
             PreviewProvider.webviewPanel.reveal(vscode.ViewColumn.Beside, true);
         }
-        
+
+        this.logger.info(`Opening preview: ${editor.document.fileName}`);
         await this.updatePreview(editor.document, editor);
     }
     
@@ -97,7 +101,7 @@ export class PreviewProvider {
     
     private async updatePreview(document: vscode.TextDocument, editor: vscode.TextEditor | undefined): Promise<void> {
         if (!PreviewProvider.webviewPanel) return;
-        
+
         try {
             // Avoid blanking the whole preview on transient render errors:
             // only show a full loading screen if we have nothing rendered yet.
@@ -107,6 +111,7 @@ export class PreviewProvider {
             let svg = await this.imageGenerator.generate(false, ImageFormat.SVG, document);
             svg = this.extractSvgFromOutput(svg);
             const diagramName = this.imageGenerator.findDiagramName(document, editor);
+            this.logger.debug(`Preview updated: '${diagramName}' in ${document.fileName}`);
             let highlightName = await this.getSymbolNameAtCursor(document, editor);
             if (highlightName === diagramName) highlightName = null;
             const html = this.getHtmlForWebview(svg, highlightName ?? undefined, document.uri.fsPath, diagramName, undefined, this.unsaved);
@@ -120,6 +125,7 @@ export class PreviewProvider {
             const exitCode = typeof error?.exitCode === 'number'
                 ? error.exitCode
                 : (typeof error?.code === 'number' ? error.code : undefined);
+            this.logRenderError(document.fileName, exitCode, error);
             const cleanMsg = String(error?.message ?? error)
                 .replace(/.*\[31m/, '')
                 .replace(/\[0m.*/, '')
@@ -172,12 +178,27 @@ export class PreviewProvider {
         }
     }
     
+    private logRenderError(fileName: string, exitCode: number | undefined, error: unknown): void {
+        if (exitCode === 1) {
+            this.logger.warn(`Render: model errors (exit 1) in ${fileName}`);
+        } else if (exitCode === 42) {
+            this.logger.error(`Render: compiler crash (exit 42) in ${fileName}`);
+        } else {
+            let msg: string;
+            if (error instanceof Error) { msg = error.message; }
+            else if (typeof error === 'string') { msg = error; }
+            else { msg = '[unknown error]'; }
+            this.logger.error(`Render failed in ${fileName}: ${msg}`);
+        }
+    }
+
     /** Update only which node is highlighted (no SVG reload). */
     private async updateHighlightOnly(document: vscode.TextDocument, editor: vscode.TextEditor | undefined): Promise<void> {
         if (!PreviewProvider.webviewPanel) return;
         const diagramName = this.imageGenerator.findDiagramName(document, editor);
         let name = await this.getSymbolNameAtCursor(document, editor);
         if (name === diagramName) name = null;
+        this.logger.trace(`Highlight-only update: '${name ?? '(none)'}' in '${diagramName}'`);
         PreviewProvider.webviewPanel.webview.postMessage({ type: 'highlight', name: name ?? null });
     }
     
@@ -245,6 +266,7 @@ export class PreviewProvider {
         panel.onDidDispose(() => {
             PreviewProvider.webviewPanel = undefined;
             PreviewProvider.webviewDisposed = true;
+            this.logger.info('Webview panel disposed');
         });
         
         panel.webview.onDidReceiveMessage((msg: { type?: string; format?: string; url?: string }) => {

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -198,7 +198,7 @@ export class PreviewProvider {
         const diagramName = this.imageGenerator.findDiagramName(document, editor);
         let name = await this.getSymbolNameAtCursor(document, editor);
         if (name === diagramName) name = null;
-        this.logger.trace(`Highlight-only update: '${name ?? '(none)'}' in '${diagramName}'`);
+        if (this.logger.shouldLog('trace')) this.logger.trace(`Highlight-only update: '${name ?? '(none)'}' in '${diagramName}'`);
         PreviewProvider.webviewPanel.webview.postMessage({ type: 'highlight', name: name ?? null });
     }
     

--- a/packages/extension/src/extension/logger.ts
+++ b/packages/extension/src/extension/logger.ts
@@ -23,6 +23,8 @@ export class JpipeLogger {
         return idx === -1 ? ORDER.indexOf('info') : idx;
     }
 
+    shouldLog(level: LogLevel): boolean { return ORDER.indexOf(level) <= this.rank; }
+
     trace(msg: string): void { this.write(5, 'TRACE', msg); }
     debug(msg: string): void { this.write(4, 'DEBUG', msg); }
     info(msg: string):  void { this.write(3, 'INFO ', msg); }

--- a/packages/extension/src/extension/logger.ts
+++ b/packages/extension/src/extension/logger.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+
+export type LogLevel = 'off' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
+
+const ORDER: LogLevel[] = ['off', 'error', 'warn', 'info', 'debug', 'trace'];
+
+export class JpipeLogger {
+    private readonly channel: vscode.OutputChannel;
+    private rank: number;
+
+    constructor(context: vscode.ExtensionContext) {
+        this.channel = vscode.window.createOutputChannel('jPipe');
+        context.subscriptions.push(this.channel);
+        this.rank = this.readRank();
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('jpipe.logLevel')) this.rank = this.readRank();
+        }, undefined, context.subscriptions);
+    }
+
+    private readRank(): number {
+        const level = vscode.workspace.getConfiguration('jpipe').get<string>('logLevel', 'info');
+        const idx = ORDER.indexOf(level as LogLevel);
+        return idx === -1 ? ORDER.indexOf('info') : idx;
+    }
+
+    trace(msg: string): void { this.write(5, 'TRACE', msg); }
+    debug(msg: string): void { this.write(4, 'DEBUG', msg); }
+    info(msg: string):  void { this.write(3, 'INFO ', msg); }
+    warn(msg: string):  void { this.write(2, 'WARN ', msg); }
+    error(msg: string): void { this.write(1, 'ERROR', msg); }
+
+    private write(rank: number, label: string, msg: string): void {
+        if (rank > this.rank) return;
+        this.channel.appendLine(`${new Date().toISOString()} [${label}] ${msg}`);
+    }
+}

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -4,18 +4,21 @@ import * as path from 'node:path';
 import { LanguageClient, TransportKind, Trace, RevealOutputChannelOn } from 'vscode-languageclient/node.js';
 import { ImageGenerator, ImageFormat } from './image-generation/image-generator.js';
 import { PreviewProvider } from './image-generation/preview-provider.js';
+import { JpipeLogger } from './logger.js';
 
 let client: LanguageClient;
 
 // This function is called when the extension is activated.
 export function activate(context: vscode.ExtensionContext): void {
-    client = startLanguageClient(context);
-    
+    const logger = new JpipeLogger(context);
+    logger.info('jPipe extension activated');
+
+    client = startLanguageClient(context, logger);
+
     // Create image generator and preview provider (client passed for cursor→node highlighting)
-    const imageGenerator = new ImageGenerator();
-    const previewProvider = new PreviewProvider(imageGenerator, client, context);
-    
-    // Register download commands for all supported formats
+    const imageGenerator = new ImageGenerator(logger);
+    const previewProvider = new PreviewProvider(imageGenerator, client, context, logger);
+
     context.subscriptions.push(
         vscode.commands.registerCommand('jpipe.downloadPNG',    () => imageGenerator.generateAndSave(ImageFormat.PNG)),
         vscode.commands.registerCommand('jpipe.downloadSVG',    () => imageGenerator.generateAndSave(ImageFormat.SVG)),
@@ -23,17 +26,8 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand('jpipe.downloadJPEG',   () => imageGenerator.generateAndSave(ImageFormat.JPEG)),
         vscode.commands.registerCommand('jpipe.downloadDOT',    () => imageGenerator.generateAndSave(ImageFormat.DOT)),
         vscode.commands.registerCommand('jpipe.downloadPython', () => imageGenerator.generateAndSave(ImageFormat.PYTHON)),
-        vscode.commands.registerCommand('jpipe.downloadJPIPE',  () => imageGenerator.generateAndSave(ImageFormat.JPIPE))
-    );
-    
-    // Register preview command
-    context.subscriptions.push(
-        vscode.commands.registerCommand('jpipe.vis.preview', () => {
-            previewProvider.openPreview();
-        })
-    );
-
-    context.subscriptions.push(
+        vscode.commands.registerCommand('jpipe.downloadJPIPE',  () => imageGenerator.generateAndSave(ImageFormat.JPIPE)),
+        vscode.commands.registerCommand('jpipe.vis.preview', () => previewProvider.openPreview()),
         vscode.commands.registerCommand('jpipe.checkInstallation', async () => {
             const { ok, message } = await imageGenerator.check();
             if (ok) {
@@ -53,15 +47,18 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
 }
 
-function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
+function startLanguageClient(context: vscode.ExtensionContext, logger: JpipeLogger): LanguageClient {
     const serverModule = context.asAbsolutePath(path.join('out', 'language', 'main.cjs'));
-    const debugOptions = { 
-        execArgv: ['--nolazy', `--inspect${process.env.DEBUG_BREAK ? '-brk' : ''}=${process.env.DEBUG_SOCKET || '6009'}`] 
+    const debugOptions = {
+        execArgv: ['--nolazy', `--inspect${process.env.DEBUG_BREAK ? '-brk' : ''}=${process.env.DEBUG_SOCKET || '6009'}`]
     };
 
+    const logLevel = vscode.workspace.getConfiguration('jpipe').get<string>('logLevel', 'info');
+    const serverEnv = { ...process.env, JPIPE_LOG_LEVEL: logLevel };
+
     const serverOptions: ServerOptions = {
-        run: { module: serverModule, transport: TransportKind.ipc },
-        debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
+        run:   { module: serverModule, transport: TransportKind.ipc, options: { env: serverEnv } },
+        debug: { module: serverModule, transport: TransportKind.ipc, options: { ...debugOptions, env: serverEnv } }
     };
 
     const outputChannel = vscode.window.createOutputChannel('jPipe Language Server');
@@ -81,13 +78,20 @@ function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
         clientOptions
     );
 
-    client.start().catch((error: unknown) => {
-        vscode.window.showErrorMessage(`Failed to start language server: ${error}`);
+    client.start().then(() => {
+        logger.info(`Language server started (log level: ${logLevel})`);
+    }).catch((error: unknown) => {
+        let msg: string;
+        if (error instanceof Error) { msg = error.message; }
+        else if (typeof error === 'string') { msg = error; }
+        else { msg = '[unknown error]'; }
+        logger.error(`Failed to start language server: ${msg}`);
+        vscode.window.showErrorMessage(`Failed to start language server: ${msg}`);
     });
 
     // Bring back protocol tracing (shows requests/notifications in trace channel).
     // Note: We intentionally don't await this; the client will apply it once connected.
     void client.setTrace(Trace.Verbose);
-    
+
     return client;
 }

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -63,6 +63,7 @@ function startLanguageClient(context: vscode.ExtensionContext, logger: JpipeLogg
 
     const outputChannel = vscode.window.createOutputChannel('jPipe Language Server');
     const traceOutputChannel = vscode.window.createOutputChannel('jPipe Language Server (Trace)');
+    context.subscriptions.push(outputChannel, traceOutputChannel);
 
     const clientOptions: LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'jpipe' }],

--- a/packages/extension/src/language/main.ts
+++ b/packages/extension/src/language/main.ts
@@ -2,12 +2,15 @@ import { startLanguageServer } from 'langium/lsp';
 import { NodeFileSystem } from 'langium/node';
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node.js';
 import { createJpipeServices } from 'jpipe-language';
+import type { LogLevel } from 'jpipe-language';
 
 // Create a connection to the client
 const connection = createConnection(ProposedFeatures.all);
 
+const logLevel = (process.env.JPIPE_LOG_LEVEL ?? 'info') as LogLevel;
+
 // Inject the shared services and language-specific services
-const { shared } = createJpipeServices({ connection, ...NodeFileSystem });
+const { shared } = createJpipeServices({ connection, ...NodeFileSystem }, logLevel);
 
 // Start the language server with the shared services
 startLanguageServer(shared);

--- a/packages/language/src/index.ts
+++ b/packages/language/src/index.ts
@@ -1,5 +1,6 @@
 export * from './jpipe-module.js';
 export * from './jpipe-validator.js';
+export * from './jpipe-logger.js';
 export * from './generated/ast.js';
 export * from './generated/grammar.js';
 export * from './generated/module.js';

--- a/packages/language/src/jpipe-completion.ts
+++ b/packages/language/src/jpipe-completion.ts
@@ -10,6 +10,7 @@ import {
 import { Position, type TextEdit, CompletionItem, CompletionItemKind, CompletionList, CompletionParams } from 'vscode-languageserver';
 import * as path from 'node:path';
 import type { JpipeServices } from './jpipe-module.js';
+import type { JpipeServerLogger } from './jpipe-logger.js';
 import {
     isJustification,
     isTemplate,
@@ -31,6 +32,7 @@ import { getAllElements, getLocalElements, qualifiedIdText } from './jpipe-utils
 
 export class JpipeCompletionProvider extends DefaultCompletionProvider {
     private readonly services: JpipeServices;
+    private readonly logger: JpipeServerLogger;
 
     /** So VS Code requests completion when `@` is typed (e.g. for `@support`). */
     override readonly completionOptions: CompletionProviderOptions = {
@@ -40,6 +42,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
     public constructor(services: JpipeServices) {
         super(services);
         this.services = services;
+        this.logger = services.logger;
     }
 
     private get importService() {
@@ -316,6 +319,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
     }
 
     private getTemplateElementCompletions(context: CompletionContext): CompletionItem[] {
+        this.logger.debug(`Completion request at line ${context.position.line}:${context.position.character}`);
         try {
             const currentNode = context.node;
             if (!currentNode) return [];
@@ -345,7 +349,8 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
                 }
             }
             return completions;
-        } catch {
+        } catch (error) {
+            this.logger.error(`getTemplateElementCompletions failed: ${error instanceof Error ? error.message : String(error)}`);
             return [];
         }
     }

--- a/packages/language/src/jpipe-completion.ts
+++ b/packages/language/src/jpipe-completion.ts
@@ -319,7 +319,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
     }
 
     private getTemplateElementCompletions(context: CompletionContext): CompletionItem[] {
-        this.logger.debug(`Completion request at line ${context.position.line}:${context.position.character}`);
+        if (this.logger.shouldLog('debug')) this.logger.debug(`Completion request at line ${context.position.line}:${context.position.character}`);
         try {
             const currentNode = context.node;
             if (!currentNode) return [];

--- a/packages/language/src/jpipe-import.ts
+++ b/packages/language/src/jpipe-import.ts
@@ -1,5 +1,6 @@
 import { URI, type LangiumDocument, AstUtils, type AstNode } from 'langium';
 import type { JpipeServices } from './jpipe-module.js';
+import type { JpipeServerLogger } from './jpipe-logger.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import {
@@ -16,9 +17,11 @@ import { getAllElements } from './jpipe-utils.js';
  */
 export class JpipeImportService {
     private readonly services: JpipeServices;
+    private readonly logger: JpipeServerLogger;
 
     public constructor(services: JpipeServices) {
         this.services = services;
+        this.logger = services.logger;
     }
 
     resolveImport(filePath: string, currentDoc: LangiumDocument): LangiumDocument | undefined {
@@ -65,6 +68,7 @@ export class JpipeImportService {
         }
 
         if (!fs.existsSync(resolvedPath)) {
+            this.logger.warn(`Import not found: ${resolvedPath}`);
             return undefined;
         }
 
@@ -79,9 +83,10 @@ export class JpipeImportService {
                 this.setDocumentOnAllNodes(doc.parseResult.value, doc);
             }
 
+            this.logger.debug(`Parsed import: ${resolvedPath}`);
             return doc;
         } catch (error) {
-            console.error('[jPipe] Failed to parse document:', error);
+            this.logger.error(`Failed to parse document: ${resolvedPath}: ${error instanceof Error ? error.message : String(error)}`);
             return undefined;
         }
     }
@@ -183,6 +188,7 @@ export class JpipeImportService {
             }
         }
 
+        this.logger.debug(`BFS import traversal: ${out.length} document(s) reachable`);
         return out;
     }
 

--- a/packages/language/src/jpipe-logger.ts
+++ b/packages/language/src/jpipe-logger.ts
@@ -1,0 +1,18 @@
+export type LogLevel = 'off' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
+
+const ORDER: LogLevel[] = ['off', 'error', 'warn', 'info', 'debug', 'trace'];
+
+export class JpipeServerLogger {
+    private readonly rank: number;
+
+    constructor(level: LogLevel = 'info') {
+        const idx = ORDER.indexOf(level);
+        this.rank = idx === -1 ? ORDER.indexOf('info') : idx;
+    }
+
+    error(msg: string): void { if (this.rank >= 1) console.error(`[jPipe] ERROR ${msg}`); }
+    warn(msg: string):  void { if (this.rank >= 2) console.warn(`[jPipe] WARN  ${msg}`); }
+    info(msg: string):  void { if (this.rank >= 3) console.log(`[jPipe] INFO  ${msg}`); }
+    debug(msg: string): void { if (this.rank >= 4) console.log(`[jPipe] DEBUG ${msg}`); }
+    trace(msg: string): void { if (this.rank >= 5) console.log(`[jPipe] TRACE ${msg}`); }
+}

--- a/packages/language/src/jpipe-logger.ts
+++ b/packages/language/src/jpipe-logger.ts
@@ -10,6 +10,8 @@ export class JpipeServerLogger {
         this.rank = idx === -1 ? ORDER.indexOf('info') : idx;
     }
 
+    shouldLog(level: LogLevel): boolean { return ORDER.indexOf(level) <= this.rank; }
+
     error(msg: string): void { if (this.rank >= 1) console.error(`[jPipe] ERROR ${msg}`); }
     warn(msg: string):  void { if (this.rank >= 2) console.warn(`[jPipe] WARN  ${msg}`); }
     info(msg: string):  void { if (this.rank >= 3) console.log(`[jPipe] INFO  ${msg}`); }

--- a/packages/language/src/jpipe-module.ts
+++ b/packages/language/src/jpipe-module.ts
@@ -5,6 +5,7 @@ import { JpipeValidator, registerValidationChecks } from './jpipe-validator.js';
 import { JpipeScopeProvider } from './jpipe-scope.js';
 import { JpipeImportService } from './jpipe-import.js';
 import { JpipeCompletionProvider } from './jpipe-completion.js';
+import { JpipeServerLogger, type LogLevel } from './jpipe-logger.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -15,7 +16,8 @@ export type JpipeAddedServices = {
     },
     references: {
         JpipeImportService: JpipeImportService
-    }
+    },
+    logger: JpipeServerLogger
 }
 
 /**
@@ -24,23 +26,21 @@ export type JpipeAddedServices = {
  */
 export type JpipeServices = LangiumServices & JpipeAddedServices
 
-/**
- * Dependency injection module that overrides Langium default services and contributes the
- * declared custom services. The Langium defaults can be partially specified to override only
- * selected services, while the custom services must be fully specified.
- */
-export const JpipeModule: Module<JpipeServices, PartialLangiumServices & JpipeAddedServices> = {
-    validation: {
-        JpipeValidator: () => new JpipeValidator()
-    },
-    references: {
-        ScopeProvider: (services) => new JpipeScopeProvider(services),
-        JpipeImportService: (services) => new JpipeImportService(services)
-    },
-    lsp: {
-        CompletionProvider: (services) => new JpipeCompletionProvider(services)
-    }
-};
+function buildJpipeModule(logger: JpipeServerLogger): Module<JpipeServices, PartialLangiumServices & JpipeAddedServices> {
+    return {
+        validation: {
+            JpipeValidator: (services) => new JpipeValidator(services)
+        },
+        references: {
+            ScopeProvider: (services) => new JpipeScopeProvider(services),
+            JpipeImportService: (services) => new JpipeImportService(services)
+        },
+        lsp: {
+            CompletionProvider: (services) => new JpipeCompletionProvider(services)
+        },
+        logger: () => logger
+    };
+}
 
 /**
  * Create the full set of services required by Langium.
@@ -55,12 +55,14 @@ export const JpipeModule: Module<JpipeServices, PartialLangiumServices & JpipeAd
  *  - Services specified in this file
  *
  * @param context Optional module context with the LSP connection
+ * @param logLevel Controls verbosity of the language server log (default: 'info')
  * @returns An object wrapping the shared services and the language-specific services
  */
-export function createJpipeServices(context: DefaultSharedModuleContext): {
+export function createJpipeServices(context: DefaultSharedModuleContext, logLevel: LogLevel = 'info'): {
     shared: LangiumSharedServices,
     Jpipe: JpipeServices
 } {
+    const logger = new JpipeServerLogger(logLevel);
     const shared = inject(
         createDefaultSharedModule(context),
         JpipeGeneratedSharedModule
@@ -68,7 +70,7 @@ export function createJpipeServices(context: DefaultSharedModuleContext): {
     const Jpipe = inject(
         createDefaultModule({ shared }),
         JpipeGeneratedModule,
-        JpipeModule
+        buildJpipeModule(logger)
     );
     shared.ServiceRegistry.register(Jpipe);
     registerValidationChecks(Jpipe);

--- a/packages/language/src/jpipe-scope.ts
+++ b/packages/language/src/jpipe-scope.ts
@@ -1,5 +1,6 @@
 import { DefaultScopeProvider, AstUtils, type ReferenceInfo, type LangiumDocument } from 'langium';
 import { type JpipeServices } from './jpipe-module.js';
+import type { JpipeServerLogger } from './jpipe-logger.js';
 import {
     isJustification,
     isTemplate,
@@ -12,10 +13,12 @@ import { getAllElements, qualifiedIdText } from './jpipe-utils.js';
 
 export class JpipeScopeProvider extends DefaultScopeProvider {
     private readonly services: JpipeServices;
+    private readonly logger: JpipeServerLogger;
 
     public constructor(services: JpipeServices) {
         super(services);
         this.services = services;
+        this.logger = services.logger;
     }
 
     private get importService() {
@@ -23,6 +26,7 @@ export class JpipeScopeProvider extends DefaultScopeProvider {
     }
 
     override getScope(context: ReferenceInfo) {
+        this.logger.debug(`Scope resolution: property='${context.property}' container=${context.container.$type}`);
         if (context.property === 'parent' && (isJustification(context.container) || isTemplate(context.container))) {
             const { document, unit } = this.getDocumentAndUnit(context.container);
             if (document && unit) {

--- a/packages/language/src/jpipe-scope.ts
+++ b/packages/language/src/jpipe-scope.ts
@@ -26,7 +26,7 @@ export class JpipeScopeProvider extends DefaultScopeProvider {
     }
 
     override getScope(context: ReferenceInfo) {
-        this.logger.debug(`Scope resolution: property='${context.property}' container=${context.container.$type}`);
+        if (this.logger.shouldLog('debug')) this.logger.debug(`Scope resolution: property='${context.property}' container=${context.container.$type}`);
         if (context.property === 'parent' && (isJustification(context.container) || isTemplate(context.container))) {
             const { document, unit } = this.getDocumentAndUnit(context.container);
             if (document && unit) {

--- a/packages/language/src/jpipe-validator.ts
+++ b/packages/language/src/jpipe-validator.ts
@@ -21,6 +21,7 @@ import {
     isSubConclusion
 } from './generated/ast.js';
 import type { JpipeServices } from './jpipe-module.js';
+import type { JpipeServerLogger } from './jpipe-logger.js';
 import { getAllElements, getLocalElements, qualifiedIdText } from './jpipe-utils.js';
 
 export function registerValidationChecks(services: JpipeServices) {
@@ -40,6 +41,11 @@ export function registerValidationChecks(services: JpipeServices) {
 }
 
 export class JpipeValidator {
+    private readonly logger: JpipeServerLogger;
+
+    constructor(services: JpipeServices) {
+        this.logger = services.logger;
+    }
 
     checkLabelNotEmpty(element: Evidence | Strategy | Conclusion | SubConclusion | AbstractSupport,
                         accept: ValidationAcceptor): void {
@@ -57,6 +63,7 @@ export class JpipeValidator {
     }
 
     checkDuplicateTemplateName(template: Template, accept: ValidationAcceptor): void {
+        this.logger.debug(`Validating template '${template.id}'`);
         const unit = template.$container;
         if (!unit) return;
 
@@ -82,6 +89,7 @@ export class JpipeValidator {
     }
 
     checkDuplicateJustificationName(justification: Justification, accept: ValidationAcceptor): void {
+        this.logger.debug(`Validating justification '${justification.id}'`);
         const unit = justification.$container;
         if (!unit) return;
 
@@ -137,6 +145,7 @@ export class JpipeValidator {
     }
 
     checkJustificationOverride(justification: Justification, accept: ValidationAcceptor): void {
+        this.logger.debug(`Checking overrides for justification '${justification.id}'`);
         if (!justification.parent?.ref) return;
 
         const template = justification.parent.ref;


### PR DESCRIPTION
This pull request introduces a new configurable logging system for the jPipe VS Code extension and language server, allowing users to control log verbosity through settings. It adds a `JpipeLogger` class for structured logging, integrates this logger throughout the extension and preview components, and ensures that log level is propagated to the language server. Additionally, error handling and diagnostics are enhanced with more precise log messages. Minor updates include contributor list formatting.

**Logging enhancements and configuration:**

* Added a new `jpipe.logLevel` setting to `package.json`, allowing users to select the verbosity of the jPipe log channel in the VS Code Output panel.
* Introduced the `JpipeLogger` class in `logger.ts` for structured, level-based logging throughout the extension, with dynamic configuration updates.
* All extension components (`main.ts`, `image-generator.ts`, `preview-provider.ts`) now use `JpipeLogger` for info, debug, warn, error, and trace logs instead of console logging. [[1]](diffhunk://#diff-a5c7facc38f10575638877ebaefeab0ece79ea204d773afeec5eb9f202554aedR7-R30) [[2]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26R7) [[3]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939R4)

**Integration with language server:**

* The extension now passes the selected log level to the language server via the `JPIPE_LOG_LEVEL` environment variable, and the language server consumes this to set its own log level. [[1]](diffhunk://#diff-a5c7facc38f10575638877ebaefeab0ece79ea204d773afeec5eb9f202554aedL56-R61) [[2]](diffhunk://#diff-72decb3b08c779679ecf8d15d2fd294af7620d913c433fc4118be75c3d7b06efR5-R13)
* The language server's completion provider and service modules are updated to use the logger, enabling consistent logging on both client and server sides. [[1]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R13) [[2]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R35) [[3]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R45) [[4]](diffhunk://#diff-255e6b5c55a6b568df10ddc47b4079b801a9c4e8801b21f0fed7b7f69dcada59R3)

**Improved error handling and diagnostics:**

* Enhanced error reporting in image generation and preview rendering with detailed, level-appropriate log messages for different failure scenarios (e.g., compiler errors, crashes). [[1]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26R99-R102) [[2]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L115-R125) [[3]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26R188-R198) [[4]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939R41-R46) [[5]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939R114) [[6]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939R128) [[7]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939R181-R201) [[8]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939R269)

**Other changes:**

* Minor update to the contributor list in `README.md` to correct formatting.