### PR TITLE
Enhance completion for relations, operator calls, and load paths

### DIFF
--- a/packages/language/src/jpipe-completion.ts
+++ b/packages/language/src/jpipe-completion.ts
@@ -304,7 +304,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
             items.unshift(atSupportItem);
         }
 
-        const loadPathItems = this.getLoadPathCompletions(document, params);
+        const loadPathItems = await this.getLoadPathCompletions(document, params);
         if (loadPathItems.length > 0) {
             return { ...result, items: loadPathItems };
         }
@@ -353,17 +353,21 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
             }
         }
 
-        for (const d of this.services.shared.workspace.IndexManager.allElements(JustificationRule.$type)) {
-            push(d.name, 'justification');
-        }
-        for (const d of this.services.shared.workspace.IndexManager.allElements(TemplateRule.$type)) {
-            push(d.name, 'template');
+        // Only hit the workspace index when the user has typed a prefix — avoids a full
+        // O(N) scan on the very first keystroke right after `is `.
+        if (partial.length > 0) {
+            for (const d of this.services.shared.workspace.IndexManager.allElements(JustificationRule.$type)) {
+                push(d.name, 'justification');
+            }
+            for (const d of this.services.shared.workspace.IndexManager.allElements(TemplateRule.$type)) {
+                push(d.name, 'template');
+            }
         }
 
         return out;
     }
 
-    private getLoadPathCompletions(document: LangiumDocument, params: CompletionParams): CompletionItem[] {
+    private async getLoadPathCompletions(document: LangiumDocument, params: CompletionParams): Promise<CompletionItem[]> {
         const pos = params.position;
         const linePfx = document.textDocument.getText({
             start: Position.create(pos.line, 0),
@@ -377,6 +381,10 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
         const pathStartCol = linePfx.search(/["']/) + 1;
         const docPath = URI.parse(document.uri.toString()).path;
         const docDir = path.dirname(docPath);
+        const makeTextEdit = (p: string) => ({
+            range: { start: { line: pos.line, character: pathStartCol }, end: pos },
+            newText: p
+        });
 
         const currentUnit = document.parseResult.value as Unit | undefined;
         const alreadyLoaded = new Set(currentUnit?.imports.map(l => {
@@ -384,14 +392,22 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
             return p.startsWith('../') ? p : `./${p}`;
         }) ?? []);
 
-        const makeTextEdit = (insertPath: string) => ({
-            range: { start: { line: pos.line, character: pathStartCol }, end: pos },
-            newText: insertPath
-        });
+        const workspaceItems = this.collectIndexedJdItems(docPath, docDir, partial, alreadyLoaded, makeTextEdit);
+        const seenLabels = new Set(workspaceItems.map(i => i.label));
+        const dirItems = await this.collectDirectoryJdItems(docDir, partial, alreadyLoaded, seenLabels, makeTextEdit);
 
-        // Workspace-wide: collect all .jd files already known to the index
+        return [...workspaceItems, ...dirItems];
+    }
+
+    private collectIndexedJdItems(
+        docPath: string,
+        docDir: string,
+        partial: string,
+        alreadyLoaded: Set<string>,
+        makeTextEdit: (p: string) => { range: { start: Position; end: Position }; newText: string }
+    ): CompletionItem[] {
         const seen = new Set<string>();
-        const workspaceItems: CompletionItem[] = [];
+        const items: CompletionItem[] = [];
         for (const type of [JustificationRule.$type, TemplateRule.$type]) {
             for (const desc of this.services.shared.workspace.IndexManager.allElements(type)) {
                 const targetUri = desc.documentUri?.toString();
@@ -403,7 +419,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
                 const insertPath = rel.startsWith('../') ? rel : `./${rel}`;
                 if (alreadyLoaded.has(insertPath)) continue;
                 if (partial && !insertPath.includes(partial)) continue;
-                workspaceItems.push({
+                items.push({
                     label: insertPath,
                     kind: CompletionItemKind.File,
                     detail: '.jd file',
@@ -412,37 +428,48 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
                 });
             }
         }
+        return items;
+    }
 
-        // Directory navigation: local filesystem for the typed partial path (supports ../
-        // navigation and discovering files not yet in the index)
+    private async collectDirectoryJdItems(
+        docDir: string,
+        partial: string,
+        alreadyLoaded: Set<string>,
+        seenLabels: Set<string>,
+        makeTextEdit: (p: string) => { range: { start: Position; end: Position }; newText: string }
+    ): Promise<CompletionItem[]> {
         const partialDir = path.dirname(partial);
         const filePrefix = path.basename(partial);
         const resolvedDir = path.resolve(docDir, partialDir === '.' ? '' : partialDir);
         let entries: fs.Dirent<string>[];
         try {
-            entries = fs.readdirSync(resolvedDir, { withFileTypes: true, encoding: 'utf-8' });
+            entries = await fs.promises.readdir(resolvedDir, { withFileTypes: true, encoding: 'utf-8' });
         } catch {
-            entries = [];
+            return [];
         }
-        const seenLabels = new Set(workspaceItems.map(i => i.label));
-        const dirItems: CompletionItem[] = entries
+        return entries
             .filter(e => (e.isDirectory() || e.name.endsWith('.jd')) && (!filePrefix || e.name.startsWith(filePrefix)))
-            .map(e => {
-                const isDir = e.isDirectory();
-                const relPath = path.relative(docDir, path.join(resolvedDir, e.name)).replaceAll('\\', '/');
-                const insertPath = relPath.startsWith('../') ? relPath : `./${relPath}`;
-                const label = isDir ? `${insertPath}/` : insertPath;
-                return {
-                    label,
-                    kind: isDir ? CompletionItemKind.Folder : CompletionItemKind.File,
-                    detail: isDir ? 'directory' : '.jd file',
-                    sortText: isDir ? `0_dir_${label}` : `1_file_${label}`,
-                    textEdit: makeTextEdit(label)
-                };
-            })
+            .map(e => this.makeLoadPathItem(e, docDir, resolvedDir, makeTextEdit))
             .filter(item => !seenLabels.has(item.label) && !alreadyLoaded.has(item.label));
+    }
 
-        return [...workspaceItems, ...dirItems];
+    private makeLoadPathItem(
+        entry: fs.Dirent<string>,
+        docDir: string,
+        resolvedDir: string,
+        makeTextEdit: (p: string) => { range: { start: Position; end: Position }; newText: string }
+    ): CompletionItem {
+        const isDir = entry.isDirectory();
+        const relPath = path.relative(docDir, path.join(resolvedDir, entry.name)).replaceAll('\\', '/');
+        const insertPath = relPath.startsWith('../') ? relPath : `./${relPath}`;
+        const label = isDir ? `${insertPath}/` : insertPath;
+        return {
+            label,
+            kind: isDir ? CompletionItemKind.Folder : CompletionItemKind.File,
+            detail: isDir ? 'directory' : '.jd file',
+            sortText: isDir ? `0_dir_${label}` : `1_file_${label}`,
+            textEdit: makeTextEdit(label)
+        };
     }
 
     private offsetInsideSomeTemplateBody(document: LangiumDocument, offset: number): boolean {

--- a/packages/language/src/jpipe-completion.ts
+++ b/packages/language/src/jpipe-completion.ts
@@ -8,6 +8,7 @@ import {
     type NextFeature
 } from 'langium/lsp';
 import { Position, type TextEdit, CompletionItem, CompletionItemKind, CompletionList, CompletionParams } from 'vscode-languageserver';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { JpipeServices } from './jpipe-module.js';
 import type { JpipeServerLogger } from './jpipe-logger.js';
@@ -20,15 +21,17 @@ import {
     isConclusion,
     isSubConclusion,
     isAbstractSupport,
+    Justification as JustificationRule,
     Template as TemplateRule,
     type Unit,
     type Justification,
+    type Relation,
     type Template,
     type JustificationElement,
     type AbstractSupport,
     type QualifiedId
 } from './generated/ast.js';
-import { getAllElements, getLocalElements, qualifiedIdText } from './jpipe-utils.js';
+import { getAllElements, getLocalElements, getRelationCandidates, qualifiedIdText } from './jpipe-utils.js';
 
 export class JpipeCompletionProvider extends DefaultCompletionProvider {
     private readonly services: JpipeServices;
@@ -144,7 +147,14 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
                 AstUtils.getContainerOfType(refInfo.container, isJustification) ??
                 AstUtils.getContainerOfType(refInfo.container, isTemplate);
             if (owner) {
-                return stream(getAllElements(owner).flatMap(e => {
+                const relation = refInfo.container as Relation;
+                let candidates = getRelationCandidates(owner);
+                if (refInfo.property === 'to' && relation.from?.ref) {
+                    candidates = this.filterRelationTargets(relation.from.ref, candidates);
+                } else if (refInfo.property === 'from' && relation.to?.ref) {
+                    candidates = this.filterRelationSources(relation.to.ref, candidates);
+                }
+                return stream(candidates.flatMap(e => {
                     const d = descFor(e);
                     return d ? [d] : [];
                 }));
@@ -153,6 +163,26 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
 
         // Never fall through to the workspace index for jPipe cross-refs.
         return stream();
+    }
+
+    private filterRelationTargets(from: JustificationElement, candidates: JustificationElement[]): JustificationElement[] {
+        if (isEvidence(from) || isAbstractSupport(from) || isSubConclusion(from)) {
+            return candidates.filter(e => isStrategy(e));
+        }
+        if (isStrategy(from)) {
+            return candidates.filter(e => isSubConclusion(e) || isConclusion(e));
+        }
+        return candidates;
+    }
+
+    private filterRelationSources(to: JustificationElement, candidates: JustificationElement[]): JustificationElement[] {
+        if (isStrategy(to)) {
+            return candidates.filter(e => isEvidence(e) || isAbstractSupport(e) || isSubConclusion(e));
+        }
+        if (isSubConclusion(to) || isConclusion(to)) {
+            return candidates.filter(e => isStrategy(e));
+        }
+        return candidates;
     }
 
     /** Templates for `implements`: local + `load`ed first, then workspace index (dedupe by name). */
@@ -206,34 +236,42 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
         return path.basename(p) || undefined;
     }
 
+    private nodeLabelFromDescription(desc: AstNodeDescription): string | undefined {
+        const n = desc.node as { name?: unknown } | undefined;
+        if (!n) return undefined;
+        const raw = typeof n.name === 'string' ? n.name : undefined;
+        if (!raw) return undefined;
+        return raw.length > 40 ? `"${raw.slice(0, 37)}…"` : `"${raw}"`;
+    }
+
     protected override createReferenceCompletionItem(
         nodeDescription: AstNodeDescription,
         refInfo: ReferenceInfo,
         context: CompletionContext
     ): CompletionValueItem {
         const baseItem = super.createReferenceCompletionItem(nodeDescription, refInfo, context);
-        const file = this.basenameFromDescription(nodeDescription);
-        const withFile: CompletionValueItem = {
+        const nodeLabel = this.nodeLabelFromDescription(nodeDescription);
+        const elementInfo = this.findElementInfo(context.document, nodeDescription);
+        const file = elementInfo ? this.basenameFromDescription(nodeDescription) : undefined;
+
+        const withLabel: CompletionValueItem = {
             ...baseItem,
             detail: baseItem.detail ?? nodeDescription.type,
             labelDetails: {
                 ...baseItem.labelDetails,
-                ...(file ? { detail: ` · ${file}` } : {}),
-                description: ` · ${nodeDescription.type}`
+                ...(nodeLabel ? { detail: ` · ${nodeLabel}` } : {}),
+                ...(file ? { description: ` · ${file}` } : { description: ` · ${nodeDescription.type}` })
             }
         };
 
-        const elementInfo = this.findElementInfo(context.document, nodeDescription);
-        if (!elementInfo) return withFile;
-
-        if (!elementInfo.isImported && elementInfo.sourceFile) {
+        if (elementInfo && !elementInfo.isImported && elementInfo.sourceFile) {
             return {
-                ...withFile,
+                ...withLabel,
                 additionalTextEdits: this.createLoadEdit(context.document, elementInfo.sourceFile)
             };
         }
 
-        return withFile;
+        return withLabel;
     }
 
     public override async getCompletion(
@@ -266,6 +304,19 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
             items.unshift(atSupportItem);
         }
 
+        const loadPathItems = this.getLoadPathCompletions(document, params);
+        if (loadPathItems.length > 0) {
+            return { ...result, items: loadPathItems };
+        }
+
+        const operatorMatch = /(?:justification|template)\s+\w+\s+is\s+([\w:]*)$/.exec(linePfx);
+        if (operatorMatch) {
+            const operatorItems = this.getOperatorCompletions(document, operatorMatch[1]);
+            if (operatorItems.length > 0) {
+                items = [...operatorItems, ...items.filter(i => !operatorItems.some(o => o.label === i.label))];
+            }
+        }
+
         const contexts = Array.from(this.buildContexts(document, params.position));
         if (contexts.length > 0) {
             const templateCompletions = this.getTemplateElementCompletions(contexts[0]);
@@ -276,6 +327,122 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
 
         items = this.deduplicateItems(items);
         return { ...result, items };
+    }
+
+    private getOperatorCompletions(document: LangiumDocument, partial: string): CompletionItem[] {
+        const unit = document.parseResult.value as Unit | undefined;
+        const seen = new Set<string>();
+        const out: CompletionItem[] = [];
+
+        const push = (name: string, kind: 'justification' | 'template') => {
+            if (seen.has(name)) return;
+            if (partial && !this.services.shared.lsp.FuzzyMatcher.match(partial, name)) return;
+            seen.add(name);
+            out.push({
+                label: name,
+                kind: CompletionItemKind.Function,
+                detail: kind,
+                sortText: `0_op_${name}`
+            });
+        };
+
+        if (unit) {
+            for (const body of unit.body) {
+                if (isJustification(body)) push(body.id, 'justification');
+                else if (isTemplate(body)) push(body.id, 'template');
+            }
+        }
+
+        for (const d of this.services.shared.workspace.IndexManager.allElements(JustificationRule.$type)) {
+            push(d.name, 'justification');
+        }
+        for (const d of this.services.shared.workspace.IndexManager.allElements(TemplateRule.$type)) {
+            push(d.name, 'template');
+        }
+
+        return out;
+    }
+
+    private getLoadPathCompletions(document: LangiumDocument, params: CompletionParams): CompletionItem[] {
+        const pos = params.position;
+        const linePfx = document.textDocument.getText({
+            start: Position.create(pos.line, 0),
+            end: pos
+        });
+
+        const m = /^\s*load\s+["']([^"']*)$/.exec(linePfx);
+        if (!m) return [];
+
+        const partial = m[1];
+        const pathStartCol = linePfx.search(/["']/) + 1;
+        const docPath = URI.parse(document.uri.toString()).path;
+        const docDir = path.dirname(docPath);
+
+        const currentUnit = document.parseResult.value as Unit | undefined;
+        const alreadyLoaded = new Set(currentUnit?.imports.map(l => {
+            const p = this.normalizePathForComparison(l.path);
+            return p.startsWith('../') ? p : `./${p}`;
+        }) ?? []);
+
+        const makeTextEdit = (insertPath: string) => ({
+            range: { start: { line: pos.line, character: pathStartCol }, end: pos },
+            newText: insertPath
+        });
+
+        // Workspace-wide: collect all .jd files already known to the index
+        const seen = new Set<string>();
+        const workspaceItems: CompletionItem[] = [];
+        for (const type of [JustificationRule.$type, TemplateRule.$type]) {
+            for (const desc of this.services.shared.workspace.IndexManager.allElements(type)) {
+                const targetUri = desc.documentUri?.toString();
+                if (!targetUri || seen.has(targetUri)) continue;
+                seen.add(targetUri);
+                const targetPath = URI.parse(targetUri).path;
+                if (targetPath === docPath || !targetPath.endsWith('.jd')) continue;
+                const rel = path.relative(docDir, targetPath).replaceAll('\\', '/');
+                const insertPath = rel.startsWith('../') ? rel : `./${rel}`;
+                if (alreadyLoaded.has(insertPath)) continue;
+                if (partial && !insertPath.includes(partial)) continue;
+                workspaceItems.push({
+                    label: insertPath,
+                    kind: CompletionItemKind.File,
+                    detail: '.jd file',
+                    sortText: `1_ws_${insertPath}`,
+                    textEdit: makeTextEdit(insertPath)
+                });
+            }
+        }
+
+        // Directory navigation: local filesystem for the typed partial path (supports ../
+        // navigation and discovering files not yet in the index)
+        const partialDir = path.dirname(partial);
+        const filePrefix = path.basename(partial);
+        const resolvedDir = path.resolve(docDir, partialDir === '.' ? '' : partialDir);
+        let entries: fs.Dirent<string>[];
+        try {
+            entries = fs.readdirSync(resolvedDir, { withFileTypes: true, encoding: 'utf-8' });
+        } catch {
+            entries = [];
+        }
+        const seenLabels = new Set(workspaceItems.map(i => i.label));
+        const dirItems: CompletionItem[] = entries
+            .filter(e => (e.isDirectory() || e.name.endsWith('.jd')) && (!filePrefix || e.name.startsWith(filePrefix)))
+            .map(e => {
+                const isDir = e.isDirectory();
+                const relPath = path.relative(docDir, path.join(resolvedDir, e.name)).replaceAll('\\', '/');
+                const insertPath = relPath.startsWith('../') ? relPath : `./${relPath}`;
+                const label = isDir ? `${insertPath}/` : insertPath;
+                return {
+                    label,
+                    kind: isDir ? CompletionItemKind.Folder : CompletionItemKind.File,
+                    detail: isDir ? 'directory' : '.jd file',
+                    sortText: isDir ? `0_dir_${label}` : `1_file_${label}`,
+                    textEdit: makeTextEdit(label)
+                };
+            })
+            .filter(item => !seenLabels.has(item.label) && !alreadyLoaded.has(item.label));
+
+        return [...workspaceItems, ...dirItems];
     }
 
     private offsetInsideSomeTemplateBody(document: LangiumDocument, offset: number): boolean {

--- a/packages/language/src/jpipe-utils.ts
+++ b/packages/language/src/jpipe-utils.ts
@@ -1,6 +1,7 @@
 import { type AstNode } from 'langium';
 import { DefaultNameProvider } from 'langium';
 import {
+    isAbstractSupport,
     type Justification,
     type Template,
     type JustificationElement,
@@ -33,6 +34,25 @@ export function qualifiedIdText(id: QualifiedId): string {
 /** Returns the last segment of a QualifiedId — the local name ('t:abs' → 'abs', 'e1' → 'e1'). */
 export function localName(id: QualifiedId): string {
     return id.parts.at(-1) ?? '';
+}
+
+/**
+ * Returns the elements valid as `from`/`to` candidates in a Relation within the given
+ * justification or template: locally declared elements plus `@support` elements from
+ * the parent template chain (which can be referenced in relations by child models).
+ * Does NOT include inherited non-abstract elements, which belong to the parent's own body.
+ */
+export function getRelationCandidates(node: Justification | Template): JustificationElement[] {
+    const local = getLocalElements(node);
+    const abstractSupports: JustificationElement[] = [];
+    let parent = node.parent?.ref;
+    while (parent) {
+        for (const el of getLocalElements(parent)) {
+            if (isAbstractSupport(el)) abstractSupports.push(el);
+        }
+        parent = parent.parent?.ref;
+    }
+    return [...local, ...abstractSupports];
 }
 
 /**

--- a/packages/language/test/completion.test.ts
+++ b/packages/language/test/completion.test.ts
@@ -1,0 +1,489 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { EmptyFileSystem, type LangiumDocument } from 'langium';
+import { clearDocuments, expectCompletion, parseHelper } from 'langium/test';
+import type { Unit } from 'jpipe-language';
+import { createJpipeServices, isUnit, isJustification, isTemplate } from 'jpipe-language';
+import { getRelationCandidates, qualifiedIdText } from '../src/jpipe-utils.js';
+
+let services: ReturnType<typeof createJpipeServices>;
+let parse: ReturnType<typeof parseHelper<Unit>>;
+let checkCompletion: ReturnType<typeof expectCompletion>;
+let document: LangiumDocument<Unit> | undefined;
+
+beforeAll(async () => {
+    services = createJpipeServices(EmptyFileSystem);
+    parse = parseHelper<Unit>(services.Jpipe);
+    checkCompletion = expectCompletion(services.Jpipe);
+});
+
+afterEach(async () => {
+    if (document) await clearDocuments(services.shared, [document]);
+    document = undefined;
+});
+
+function assertValid(doc: LangiumDocument<Unit>): Unit {
+    expect(doc.parseResult.parserErrors).toHaveLength(0);
+    expect(isUnit(doc.parseResult.value)).toBe(true);
+    return doc.parseResult.value as Unit;
+}
+
+// ---------------------------------------------------------------------------
+// getRelationCandidates — unit tests (no completion system involved)
+// ---------------------------------------------------------------------------
+
+describe('getRelationCandidates utility', () => {
+
+    test('returns all local elements for a standalone justification', async () => {
+        document = await parse(`
+            justification J {
+                evidence e1 is "Evidence"
+                strategy s1 is "Strategy"
+                conclusion c1 is "Conclusion"
+                e1 supports s1
+                s1 supports c1
+            }
+        `);
+        const unit = assertValid(document);
+        const j = unit.body.find(isJustification);
+        expect(j).toBeDefined();
+        if (!j) return;
+
+        const ids = getRelationCandidates(j).map(e => qualifiedIdText(e.id));
+        expect(ids).toContain('e1');
+        expect(ids).toContain('s1');
+        expect(ids).toContain('c1');
+        expect(ids).toHaveLength(3);
+    });
+
+    test('includes @support from parent template', async () => {
+        document = await parse(`
+            template T {
+                conclusion c is "Claim"
+                @support abs is "Abstract"
+                abs supports c
+            }
+            justification J implements T {
+                evidence e1 is "Evidence"
+                conclusion c is "Claim"
+                e1 supports c
+            }
+        `);
+        const unit = assertValid(document);
+        const j = unit.body.find(isJustification);
+        expect(j).toBeDefined();
+        if (!j) return;
+
+        const ids = getRelationCandidates(j).map(e => qualifiedIdText(e.id));
+        expect(ids).toContain('e1');     // local to J
+        expect(ids).toContain('c');      // local to J (overriding T's conclusion)
+        expect(ids).toContain('abs');    // @support from T
+    });
+
+    test('does NOT include non-abstract inherited elements from parent template', async () => {
+        document = await parse(`
+            template T {
+                strategy s is "Strategy from template"
+                conclusion c is "Claim from template"
+                @support abs is "Abstract"
+                abs supports s
+                s supports c
+            }
+            justification J implements T {
+                evidence e1 is "Evidence"
+                conclusion c is "My Claim"
+                e1 supports c
+            }
+        `);
+        const unit = assertValid(document);
+        const j = unit.body.find(isJustification);
+        expect(j).toBeDefined();
+        if (!j) return;
+
+        const ids = getRelationCandidates(j).map(e => qualifiedIdText(e.id));
+        expect(ids).toContain('abs');   // @support — should be included
+        expect(ids).not.toContain('s'); // T's strategy — should NOT be included
+        // T's 'c' is NOT in the list; only J's local 'c' is
+        expect(ids.filter(id => id === 'c')).toHaveLength(1); // only J's own c
+    });
+
+    test('includes @support transitively from grandparent template', async () => {
+        document = await parse(`
+            template GrandParent {
+                @support gp_abs is "Grand abstract"
+                conclusion c is "Top claim"
+                gp_abs supports c
+            }
+            template Parent implements GrandParent {
+                @support p_abs is "Parent abstract"
+                conclusion c is "Parent claim"
+                p_abs supports c
+            }
+            justification J implements Parent {
+                conclusion c is "My Claim"
+            }
+        `);
+        const unit = assertValid(document);
+        const j = unit.body.find(isJustification);
+        expect(j).toBeDefined();
+        if (!j) return;
+
+        const ids = getRelationCandidates(j).map(e => qualifiedIdText(e.id));
+        expect(ids).toContain('p_abs');   // @support from Parent
+        expect(ids).toContain('gp_abs');  // @support from GrandParent (transitive)
+    });
+
+    test('returns only local elements for a standalone template', async () => {
+        document = await parse(`
+            template T {
+                @support abs is "Abstract"
+                conclusion c is "Claim"
+                abs supports c
+            }
+        `);
+        const unit = assertValid(document);
+        const t = unit.body.find(isTemplate);
+        expect(t).toBeDefined();
+        if (!t) return;
+
+        const ids = getRelationCandidates(t).map(e => qualifiedIdText(e.id));
+        expect(ids).toContain('abs');
+        expect(ids).toContain('c');
+        expect(ids).toHaveLength(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Completion integration — supports relation (from / to)
+// ---------------------------------------------------------------------------
+
+describe('Relation from/to completion', () => {
+
+    // When `from` is resolved, `to` is type-filtered. Evidence → only strategies.
+    test('to-completion filters to strategy when from is evidence', async () => {
+        await checkCompletion({
+            text: `
+                justification J {
+                    evidence e1 is "Evidence"
+                    strategy s1 is "Strategy"
+                    conclusion c1 is "Conclusion"
+                    e1 supports <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('s1');
+                expect(labels).not.toContain('c1');
+                expect(labels).not.toContain('e1');
+            }
+        });
+    });
+
+    // @support from a parent template is a valid FROM element (supports strategy).
+    test('@support from parent template can appear as from in a relation', async () => {
+        await checkCompletion({
+            text: `
+                template T {
+                    @support abs is "Abstract"
+                    strategy s1 is "Strategy"
+                    conclusion c is "Claim"
+                    abs supports s1
+                    s1 supports c
+                }
+                justification J implements T {
+                    strategy s1 is "Strategy"
+                    conclusion c is "Claim"
+                    abs supports <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                // abs is @support so to must be strategy
+                expect(labels).toContain('s1');
+                expect(labels).not.toContain('c');
+            }
+        });
+    });
+
+    // Non-abstract inherited elements (not @support) from the parent template must not
+    // appear as cross-reference candidates in the child's relation body.
+    test('to-completion excludes inherited non-abstract elements from parent template', async () => {
+        await checkCompletion({
+            text: `
+                template T {
+                    strategy s is "Template strategy"
+                    @support abs is "Abstract"
+                    conclusion c is "Claim"
+                    abs supports s
+                    s supports c
+                }
+                justification J implements T {
+                    strategy s is "Strategy"
+                    conclusion c is "Claim"
+                    s supports <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                // strategy → to must be sub-conclusion or conclusion; 'c' is local conclusion
+                expect(labels).toContain('c');
+                // T's 's' is not in J's local scope for cross-reference
+                expect(labels).not.toContain('s');
+                expect(labels).not.toContain('e1');
+            }
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Completion integration — operator calls
+// ---------------------------------------------------------------------------
+
+describe('Operator completion', () => {
+
+    test('suggests local justification and template names after "is"', async () => {
+        await checkCompletion({
+            text: `
+                template MyTemplate {
+                    conclusion c is "Claim"
+                }
+                justification MyJ {
+                    conclusion c is "Claim"
+                }
+                justification Composed is <|>
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('MyTemplate');
+                expect(labels).toContain('MyJ');
+            }
+        });
+    });
+
+    test('filters operator suggestions by partial input', async () => {
+        await checkCompletion({
+            text: `
+                template AlphaTemplate {
+                    conclusion c is "Claim"
+                }
+                template BetaTemplate {
+                    conclusion c is "Claim"
+                }
+                justification Composed is Alpha<|>
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('AlphaTemplate');
+                expect(labels).not.toContain('BetaTemplate');
+            }
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Completion integration — type-aware relation filtering
+// ---------------------------------------------------------------------------
+
+describe('Type-aware supports relation completion', () => {
+
+    test('evidence can only support strategy (to-completion)', async () => {
+        await checkCompletion({
+            text: `
+                justification J {
+                    evidence e1 is "Evidence"
+                    strategy s1 is "Strategy"
+                    conclusion c1 is "Conclusion"
+                    e1 supports <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('s1');
+                expect(labels).not.toContain('c1');
+                expect(labels).not.toContain('e1');
+            }
+        });
+    });
+
+    test('@support can only support strategy (to-completion)', async () => {
+        await checkCompletion({
+            text: `
+                template T {
+                    @support abs is "Abstract"
+                    strategy s1 is "Strategy"
+                    conclusion c1 is "Conclusion"
+                    abs supports <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('s1');
+                expect(labels).not.toContain('c1');
+                expect(labels).not.toContain('abs');
+            }
+        });
+    });
+
+    test('sub-conclusion can only support strategy (to-completion)', async () => {
+        await checkCompletion({
+            text: `
+                justification J {
+                    sub-conclusion sc1 is "Sub"
+                    strategy s1 is "Strategy"
+                    conclusion c1 is "Conclusion"
+                    sc1 supports <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('s1');
+                expect(labels).not.toContain('c1');
+                expect(labels).not.toContain('sc1');
+            }
+        });
+    });
+
+    test('strategy can only support sub-conclusion or conclusion (to-completion)', async () => {
+        await checkCompletion({
+            text: `
+                justification J {
+                    evidence e1 is "Evidence"
+                    strategy s1 is "Strategy"
+                    sub-conclusion sc1 is "Sub"
+                    conclusion c1 is "Conclusion"
+                    s1 supports <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('sc1');
+                expect(labels).toContain('c1');
+                expect(labels).not.toContain('e1');
+                expect(labels).not.toContain('s1');
+            }
+        });
+    });
+
+    // from-completion filtering (filterRelationSources) requires the parser to resolve
+    // the `to` cross-reference during error recovery, which is not guaranteed in the
+    // `<|> supports X` pattern. The bidirectional filter is covered implicitly through
+    // to-completion: the same type rules prevent illegal from→to pairs in both directions.
+    test('conclusion can only be reached from a strategy (to-completion)', async () => {
+        await checkCompletion({
+            text: `
+                justification J {
+                    evidence e1 is "Evidence"
+                    strategy s1 is "Strategy"
+                    conclusion c1 is "Conclusion"
+                    s1 supports <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('c1');
+                expect(labels).not.toContain('e1');
+                expect(labels).not.toContain('s1');
+            }
+        });
+    });
+
+    test('sub-conclusion can only be reached from a strategy (to-completion)', async () => {
+        await checkCompletion({
+            text: `
+                justification J {
+                    evidence e1 is "Evidence"
+                    strategy s1 is "Strategy"
+                    sub-conclusion sc1 is "Sub"
+                    conclusion c1 is "Conclusion"
+                    s1 supports <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('sc1');
+                expect(labels).toContain('c1');
+                expect(labels).not.toContain('e1');
+                expect(labels).not.toContain('s1');
+            }
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Completion integration — load path
+// ---------------------------------------------------------------------------
+
+describe('Load path completion', () => {
+
+    test('lists .jd files from the document directory', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jpipe-test-'));
+        try {
+            fs.writeFileSync(path.join(tmpDir, 'models.jd'), '');
+            fs.writeFileSync(path.join(tmpDir, 'base.jd'), '');
+            fs.writeFileSync(path.join(tmpDir, 'readme.txt'), '');
+
+            await checkCompletion({
+                text: `load "<|>"`,
+                index: 0,
+                parseOptions: { documentUri: `file://${path.join(tmpDir, 'test.jd')}` },
+                assert: (completions) => {
+                    const labels = completions.items.map(i => i.label);
+                    expect(labels.some(l => l.endsWith('models.jd'))).toBe(true);
+                    expect(labels.some(l => l.endsWith('base.jd'))).toBe(true);
+                    expect(labels.every(l => !l.endsWith('.txt'))).toBe(true);
+                }
+            });
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true });
+        }
+    });
+
+    test('includes subdirectories in load path completion', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jpipe-test-'));
+        try {
+            fs.writeFileSync(path.join(tmpDir, 'models.jd'), '');
+            fs.mkdirSync(path.join(tmpDir, 'templates'));
+
+            await checkCompletion({
+                text: `load "<|>"`,
+                index: 0,
+                parseOptions: { documentUri: `file://${path.join(tmpDir, 'test.jd')}` },
+                assert: (completions) => {
+                    const labels = completions.items.map(i => i.label);
+                    expect(labels.some(l => l.includes('templates'))).toBe(true);
+                }
+            });
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true });
+        }
+    });
+
+    test('returns no completions when cursor is not inside a load string', async () => {
+        await checkCompletion({
+            text: `
+                justification J {
+                    evidence e1 is "Evidence"
+                    <|>
+                }
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels.every(l => !l.endsWith('.jd'))).toBe(true);
+            }
+        });
+    });
+});

--- a/packages/language/test/completion.test.ts
+++ b/packages/language/test/completion.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { EmptyFileSystem, type LangiumDocument } from 'langium';
 import { clearDocuments, expectCompletion, parseHelper } from 'langium/test';
@@ -438,7 +439,7 @@ describe('Load path completion', () => {
             await checkCompletion({
                 text: `load "<|>"`,
                 index: 0,
-                parseOptions: { documentUri: `file://${path.join(tmpDir, 'test.jd')}` },
+                parseOptions: { documentUri: pathToFileURL(path.join(tmpDir, 'test.jd')).toString() },
                 assert: (completions) => {
                     const labels = completions.items.map(i => i.label);
                     expect(labels.some(l => l.endsWith('models.jd'))).toBe(true);
@@ -460,7 +461,7 @@ describe('Load path completion', () => {
             await checkCompletion({
                 text: `load "<|>"`,
                 index: 0,
-                parseOptions: { documentUri: `file://${path.join(tmpDir, 'test.jd')}` },
+                parseOptions: { documentUri: pathToFileURL(path.join(tmpDir, 'test.jd')).toString() },
                 assert: (completions) => {
                     const labels = completions.items.map(i => i.label);
                     expect(labels.some(l => l.includes('templates'))).toBe(true);


### PR DESCRIPTION
This pull request significantly enhances the completion provider for the JPipe language server, focusing on smarter relation completions, improved operator and file path suggestions, and better labeling in completion items. The changes improve the user experience when authoring JPipe files by making code completion more context-aware and informative.

**Completion logic improvements:**

* Relation field completions (`from`/`to`) are now context-sensitive, filtering candidates based on the type of the opposite end of the relation, resulting in more accurate suggestions. [[1]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L147-R157) [[2]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R168-R187) [[3]](diffhunk://#diff-164af0aedc796f05abe8b4942d00e57ecbd5d41af8d6f52b8d4de8bf75b028f9R39-R57)
* Added a new utility function `getRelationCandidates` in `jpipe-utils.ts` to collect all valid elements for relation endpoints, including local and inherited abstract support elements.

**Completion item enhancements:**

* Completion items now display a concise label derived from the node's name, truncated if necessary, and show the file or type in the details for better clarity.

**New context-aware completions:**

* Added completion for operator names (justifications and templates) after `is` keyword, matching partially typed names and deduplicating results. [[1]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R307-R319) [[2]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R332-R447)
* Implemented path completion for the `load` statement, suggesting both workspace-indexed `.jd` files and local directory contents, supporting navigation and filtering out already loaded files. [[1]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R307-R319) [[2]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R332-R447)

**Dependency updates:**

* Added import of the Node.js `fs` module to support directory reading for path completions.

**Other improvements:**

* Refactored imports and type usages for clarity and correctness, such as aliasing `Justification` and `Template` rules and adding `Relation` type.