### PR TITLE
Remodel composition operators with improved grammar and completion

### DIFF
--- a/packages/language/src/jpipe-completion.ts
+++ b/packages/language/src/jpipe-completion.ts
@@ -7,7 +7,7 @@ import {
     type CompletionValueItem,
     type NextFeature
 } from 'langium/lsp';
-import { Position, type TextEdit, CompletionItem, CompletionItemKind, CompletionList, CompletionParams } from 'vscode-languageserver';
+import { Position, type TextEdit, CompletionItem, CompletionItemKind, CompletionList, CompletionParams, InsertTextFormat } from 'vscode-languageserver';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { JpipeServices } from './jpipe-module.js';
@@ -28,8 +28,7 @@ import {
     type Relation,
     type Template,
     type JustificationElement,
-    type AbstractSupport,
-    type QualifiedId
+    type AbstractSupport
 } from './generated/ast.js';
 import { getAllElements, getLocalElements, getRelationCandidates, qualifiedIdText } from './jpipe-utils.js';
 
@@ -118,27 +117,14 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
     }
 
     protected override getReferenceCandidates(refInfo: ReferenceInfo, context: CompletionContext): Stream<AstNodeDescription> {
-        const doc = context.document;
-        const unit = doc.parseResult.value as Unit | undefined;
-        if (!unit) {
-            return super.getReferenceCandidates(refInfo, context);
-        }
-
-        const descFor = (node: { id: string | QualifiedId }): AstNodeDescription | undefined => {
-            try {
-                const key = typeof node.id === 'string' ? node.id : qualifiedIdText(node.id);
-                return this.services.workspace.AstNodeDescriptionProvider.createDescription(node as any, key);
-            } catch {
-                return undefined;
-            }
-        };
-
         if (refInfo.property === 'parent') {
+            const doc = context.document;
+            const unit = doc.parseResult.value as Unit | undefined;
             const parentOwner =
                 AstUtils.getContainerOfType(refInfo.container, isJustification) ??
                 AstUtils.getContainerOfType(refInfo.container, isTemplate);
-            if (parentOwner) {
-                return stream(this.parentTemplateCandidateDescriptions(unit, doc, descFor));
+            if (unit && parentOwner) {
+                return stream(this.parentTemplateCandidateDescriptions(unit, doc));
             }
         }
 
@@ -147,6 +133,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
                 AstUtils.getContainerOfType(refInfo.container, isJustification) ??
                 AstUtils.getContainerOfType(refInfo.container, isTemplate);
             if (owner) {
+                // Filtering by sibling ref is safe here: completion runs after linking.
                 const relation = refInfo.container as Relation;
                 let candidates = getRelationCandidates(owner);
                 if (refInfo.property === 'to' && relation.from?.ref) {
@@ -155,42 +142,42 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
                     candidates = this.filterRelationSources(relation.to.ref, candidates);
                 }
                 return stream(candidates.flatMap(e => {
-                    const d = descFor(e);
-                    return d ? [d] : [];
+                    try {
+                        const key = qualifiedIdText(e.id);
+                        const d = this.services.workspace.AstNodeDescriptionProvider.createDescription(e, key);
+                        return d ? [d] : [];
+                    } catch {
+                        return [];
+                    }
                 }));
             }
         }
 
-        // Never fall through to the workspace index for jPipe cross-refs.
-        return stream();
+        // For 'refs' and other cross-refs: delegate to the scope provider via super.
+        return super.getReferenceCandidates(refInfo, context);
     }
 
     private filterRelationTargets(from: JustificationElement, candidates: JustificationElement[]): JustificationElement[] {
-        if (isEvidence(from) || isAbstractSupport(from) || isSubConclusion(from)) {
-            return candidates.filter(e => isStrategy(e));
-        }
-        if (isStrategy(from)) {
-            return candidates.filter(e => isSubConclusion(e) || isConclusion(e));
-        }
+        if (isEvidence(from) || isAbstractSupport(from) || isSubConclusion(from)) return candidates.filter(e => isStrategy(e));
+        if (isStrategy(from)) return candidates.filter(e => isSubConclusion(e) || isConclusion(e));
         return candidates;
     }
 
     private filterRelationSources(to: JustificationElement, candidates: JustificationElement[]): JustificationElement[] {
-        if (isStrategy(to)) {
-            return candidates.filter(e => isEvidence(e) || isAbstractSupport(e) || isSubConclusion(e));
-        }
-        if (isSubConclusion(to) || isConclusion(to)) {
-            return candidates.filter(e => isStrategy(e));
-        }
+        if (isStrategy(to)) return candidates.filter(e => isEvidence(e) || isAbstractSupport(e) || isSubConclusion(e));
+        if (isSubConclusion(to) || isConclusion(to)) return candidates.filter(e => isStrategy(e));
         return candidates;
     }
 
     /** Templates for `implements`: local + `load`ed first, then workspace index (dedupe by name). */
-    private parentTemplateCandidateDescriptions(
-        unit: Unit,
-        doc: LangiumDocument,
-        descFor: (node: { id: string | QualifiedId }) => AstNodeDescription | undefined
-    ): AstNodeDescription[] {
+    private parentTemplateCandidateDescriptions(unit: Unit, doc: LangiumDocument): AstNodeDescription[] {
+        const descFor = (node: Template): AstNodeDescription | undefined => {
+            try {
+                return this.services.workspace.AstNodeDescriptionProvider.createDescription(node, node.id);
+            } catch {
+                return undefined;
+            }
+        };
         const localTemplates = unit.body.filter((b): b is Template => isTemplate(b));
         const importedTemplates = this.importService.getImportedTemplates(unit, doc);
         const seen = new Set<string>();
@@ -309,11 +296,23 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
             return { ...result, items: loadPathItems };
         }
 
-        const operatorMatch = /(?:justification|template)\s+\w+\s+is\s+([\w:]*)$/.exec(linePfx);
+        const operatorMatch = /(?:justification|template)\s+\w+\s+is\s+(\w*)$/.exec(linePfx);
         if (operatorMatch) {
-            const operatorItems = this.getOperatorCompletions(document, operatorMatch[1]);
+            const operatorItems = this.getOperatorCompletions(operatorMatch[1]);
             if (operatorItems.length > 0) {
                 items = [...operatorItems, ...items.filter(i => !operatorItems.some(o => o.label === i.label))];
+            }
+        }
+
+        const textToCursor = document.textDocument.getText({
+            start: Position.create(0, 0),
+            end: pos
+        });
+        const configKeyMatch = /(?:justification|template)\s+\w+\s+is\s+(\w+)\s*\([^)]*\)\s*\{[^}]*(\w*)$/.exec(textToCursor);
+        if (configKeyMatch) {
+            const keyItems = this.getConfigKeyCompletions(configKeyMatch[1], configKeyMatch[2]);
+            if (keyItems.length > 0) {
+                items = [...keyItems, ...items.filter(i => !keyItems.some(k => k.label === i.label))];
             }
         }
 
@@ -329,42 +328,36 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
         return { ...result, items };
     }
 
-    private getOperatorCompletions(document: LangiumDocument, partial: string): CompletionItem[] {
-        const unit = document.parseResult.value as Unit | undefined;
-        const seen = new Set<string>();
-        const out: CompletionItem[] = [];
+    private static readonly KNOWN_OPERATORS = ['assemble', 'refine'] as const;
 
-        const push = (name: string, kind: 'justification' | 'template') => {
-            if (seen.has(name)) return;
-            if (partial && !this.services.shared.lsp.FuzzyMatcher.match(partial, name)) return;
-            seen.add(name);
-            out.push({
-                label: name,
-                kind: CompletionItemKind.Function,
-                detail: kind,
-                sortText: `0_op_${name}`
-            });
-        };
+    private static readonly OPERATOR_CONFIG_KEYS: Record<string, string[]> = {
+        assemble: ['conclusionLabel', 'strategyLabel'],
+        refine: ['hook']
+    };
 
-        if (unit) {
-            for (const body of unit.body) {
-                if (isJustification(body)) push(body.id, 'justification');
-                else if (isTemplate(body)) push(body.id, 'template');
-            }
-        }
+    private getOperatorCompletions(partial: string): CompletionItem[] {
+        return JpipeCompletionProvider.KNOWN_OPERATORS
+            .filter(op => !partial || this.services.shared.lsp.FuzzyMatcher.match(partial, op))
+            .map(op => ({
+                label: op,
+                kind: CompletionItemKind.Keyword,
+                detail: 'composition operator',
+                sortText: `0_op_${op}`
+            }));
+    }
 
-        // Only hit the workspace index when the user has typed a prefix — avoids a full
-        // O(N) scan on the very first keystroke right after `is `.
-        if (partial.length > 0) {
-            for (const d of this.services.shared.workspace.IndexManager.allElements(JustificationRule.$type)) {
-                push(d.name, 'justification');
-            }
-            for (const d of this.services.shared.workspace.IndexManager.allElements(TemplateRule.$type)) {
-                push(d.name, 'template');
-            }
-        }
-
-        return out;
+    private getConfigKeyCompletions(operator: string, partial: string): CompletionItem[] {
+        const keys = JpipeCompletionProvider.OPERATOR_CONFIG_KEYS[operator] ?? [];
+        return keys
+            .filter((k: string) => !partial || this.services.shared.lsp.FuzzyMatcher.match(partial, k))
+            .map((k: string) => ({
+                label: k,
+                kind: CompletionItemKind.Property,
+                detail: `${operator} argument`,
+                sortText: `0_cfg_${k}`,
+                insertText: `${k}: "$0"`,
+                insertTextFormat: InsertTextFormat.Snippet
+            }));
     }
 
     private async getLoadPathCompletions(document: LangiumDocument, params: CompletionParams): Promise<CompletionItem[]> {

--- a/packages/language/src/jpipe-import.ts
+++ b/packages/language/src/jpipe-import.ts
@@ -6,6 +6,7 @@ import * as fs from 'node:fs';
 import {
     isJustification,
     isTemplate,
+    type Justification,
     type Template,
     type JustificationElement,
     type Unit
@@ -110,6 +111,25 @@ export class JpipeImportService {
             for (const body of importedUnit.body) {
                 if (isTemplate(body)) {
                     result.push({ template: body, ns: load.namespace ?? undefined });
+                }
+            }
+        }
+        return result;
+    }
+
+    getJustificationsAndTemplatesWithNamespace(
+        unit: Unit,
+        currentDoc: LangiumDocument
+    ): Array<{ node: Justification | Template; ns: string | undefined }> {
+        const result: Array<{ node: Justification | Template; ns: string | undefined }> = [];
+        for (const load of unit.imports) {
+            const doc = this.parseDocumentFromPath(load.path, currentDoc);
+            if (!doc) continue;
+            const importedUnit = doc.parseResult.value as Unit | undefined;
+            if (!importedUnit) continue;
+            for (const body of importedUnit.body) {
+                if (isJustification(body) || isTemplate(body)) {
+                    result.push({ node: body, ns: load.namespace ?? undefined });
                 }
             }
         }

--- a/packages/language/src/jpipe-scope.ts
+++ b/packages/language/src/jpipe-scope.ts
@@ -1,9 +1,10 @@
-import { DefaultScopeProvider, AstUtils, type ReferenceInfo, type LangiumDocument } from 'langium';
+import { DefaultScopeProvider, AstUtils, type Scope, type ReferenceInfo, type LangiumDocument } from 'langium';
 import { type JpipeServices } from './jpipe-module.js';
 import type { JpipeServerLogger } from './jpipe-logger.js';
 import {
     isJustification,
     isTemplate,
+    type Composition,
     type Justification,
     type Template,
     type Unit
@@ -27,33 +28,55 @@ export class JpipeScopeProvider extends DefaultScopeProvider {
 
     override getScope(context: ReferenceInfo) {
         if (this.logger.shouldLog('debug')) this.logger.debug(`Scope resolution: property='${context.property}' container=${context.container.$type}`);
+
         if (context.property === 'parent' && (isJustification(context.container) || isTemplate(context.container))) {
-            const { document, unit } = this.getDocumentAndUnit(context.container);
-            if (document && unit) {
-                const localEntries = this.getLocalTemplates(unit)
-                    .map(t => ({ template: t, ns: undefined as string | undefined }));
-                const importedEntries = this.importService.getTemplatesWithNamespace(unit, document);
-                return this.createScopeFromTemplates([...localEntries, ...importedEntries]);
-            }
-            return super.getScope(context);
+            return this.parentScope(context.container) ?? super.getScope(context);
+        }
+
+        if (context.property === 'refs') {
+            return this.refsScope(context) ?? super.getScope(context);
         }
 
         if (context.property === 'from' || context.property === 'to') {
-            const owner = AstUtils.getContainerOfType(context.container, isJustification)
-                       ?? AstUtils.getContainerOfType(context.container, isTemplate);
-            if (owner) {
-                return this.createElementScope(owner);
-            }
+            return this.relationScope(context) ?? super.getScope(context);
         }
 
         return super.getScope(context);
     }
 
-    private createElementScope(owner: Justification | Template) {
+    private parentScope(owner: Justification | Template): Scope | undefined {
+        const { document, unit } = this.getDocumentAndUnit(owner);
+        if (!document || !unit) return undefined;
+        const localEntries = this.getLocalTemplates(unit).map(t => ({ template: t, ns: undefined as string | undefined }));
+        const importedEntries = this.importService.getTemplatesWithNamespace(unit, document);
+        return this.createScopeFromTemplates([...localEntries, ...importedEntries]);
+    }
+
+    private refsScope(context: ReferenceInfo): Scope | undefined {
+        const composition = context.container.$container as Composition;
+        const owner = composition.$container as Justification | Template;
+        const { document, unit } = this.getDocumentAndUnit(owner);
+        if (!document || !unit) return undefined;
+        const local = unit.body.filter((b): b is Justification | Template => isJustification(b) || isTemplate(b));
+        const imported = this.importService.getJustificationsAndTemplatesWithNamespace(unit, document);
+        const desc = [
+            ...local.map(n => this.descriptions.createDescription(n, n.id)),
+            ...imported.map(({ node, ns }) =>
+                this.descriptions.createDescription(node, ns ? `${ns}:${node.id}` : node.id))
+        ];
+        return this.createScope(desc);
+    }
+
+    private relationScope(context: ReferenceInfo): Scope | undefined {
+        const owner = AstUtils.getContainerOfType(context.container, isJustification)
+                   ?? AstUtils.getContainerOfType(context.container, isTemplate);
+        if (!owner) return undefined;
+        // Do NOT access sibling .ref here — scope is resolved during linking, before
+        // references are resolved, so reading a sibling .ref triggers a cycle.
+        // Relation-type filtering (e.g. evidence→strategy only) is done in the completion
+        // provider, which runs after linking is complete.
         const elements = getAllElements(owner);
-        const desc = elements.map(e =>
-            this.descriptions.createDescription(e, qualifiedIdText(e.id))
-        );
+        const desc = elements.map(e => this.descriptions.createDescription(e, qualifiedIdText(e.id)));
         return this.createScope(desc);
     }
 

--- a/packages/language/src/jpipe-validator.ts
+++ b/packages/language/src/jpipe-validator.ts
@@ -2,6 +2,7 @@ import type { ValidationAcceptor, ValidationChecks } from 'langium';
 import type {
     JpipeAstType,
     Unit,
+    Composition,
     Evidence,
     Strategy,
     Conclusion,
@@ -29,6 +30,7 @@ export function registerValidationChecks(services: JpipeServices) {
     const validator = services.validation.JpipeValidator;
     const checks: ValidationChecks<JpipeAstType> = {
         Unit:           validator.checkUnitNotEmpty,
+        Composition:    [validator.checkOperatorName, validator.checkConfigKeys],
         Template:       [validator.checkDuplicateTemplateName, validator.checkTemplateHasSupport],
         Justification:  [validator.checkDuplicateJustificationName, validator.checkJustificationOverride],
         Evidence:       validator.checkLabelNotEmpty,
@@ -43,8 +45,50 @@ export function registerValidationChecks(services: JpipeServices) {
 export class JpipeValidator {
     private readonly logger: JpipeServerLogger;
 
+    private static readonly KNOWN_OPERATORS = new Set(['assemble', 'refine']);
+
+    private static readonly OPERATOR_ALLOWED_KEYS: Record<string, Set<string>> = {
+        assemble: new Set(['conclusionLabel', 'strategyLabel']),
+        refine:   new Set(['hook'])
+    };
+
+    private static readonly OPERATOR_REQUIRED_KEYS: Record<string, Set<string>> = {
+        assemble: new Set(['conclusionLabel', 'strategyLabel']),
+        refine:   new Set(['hook'])
+    };
+
     constructor(services: JpipeServices) {
         this.logger = services.logger;
+    }
+
+    checkOperatorName(composition: Composition, accept: ValidationAcceptor): void {
+        if (!JpipeValidator.KNOWN_OPERATORS.has(composition.operator)) {
+            accept('error',
+                `Unknown operator '${composition.operator}'. Expected: ${[...JpipeValidator.KNOWN_OPERATORS].join(', ')}.`,
+                { node: composition, property: 'operator' });
+        }
+    }
+
+    checkConfigKeys(composition: Composition, accept: ValidationAcceptor): void {
+        const op = composition.operator;
+        if (!JpipeValidator.KNOWN_OPERATORS.has(op)) return;
+        const allowed = JpipeValidator.OPERATOR_ALLOWED_KEYS[op] ?? new Set<string>();
+        const required = JpipeValidator.OPERATOR_REQUIRED_KEYS[op] ?? new Set<string>();
+        const present = new Set(composition.config?.entries.map(e => e.key) ?? []);
+        for (const entry of composition.config?.entries ?? []) {
+            if (!allowed.has(entry.key)) {
+                accept('error',
+                    `Unknown config key '${entry.key}' for operator '${op}'. Allowed: ${[...allowed].join(', ')}.`,
+                    { node: entry, property: 'key' });
+            }
+        }
+        for (const key of required) {
+            if (!present.has(key)) {
+                accept('error',
+                    `Missing required config key '${key}' for operator '${op}'.`,
+                    { node: composition, property: 'operator' });
+            }
+        }
     }
 
     checkLabelNotEmpty(element: Evidence | Strategy | Conclusion | SubConclusion | AbstractSupport,

--- a/packages/language/src/jpipe.langium
+++ b/packages/language/src/jpipe.langium
@@ -8,11 +8,16 @@ Load:
 
 Justification:
     'justification' id=ID ('implements' parent=[Template:QualifiedRef])?
-    ( '{' contents=JustificationBody '}' | 'is' operator=QualifiedId '(' params=ParamsDecl? ')' config=RuleConfig? );
+    ( '{' contents=JustificationBody '}' | composition=Composition );
 
 Template:
     'template' id=ID ('implements' parent=[Template:QualifiedRef])?
-    ( '{' contents=TemplateBody '}' | 'is' operator=QualifiedId '(' params=ParamsDecl? ')' config=RuleConfig? );
+    ( '{' contents=TemplateBody '}' | composition=Composition );
+
+Composition:
+    'is' operator=ID '(' params=ParamsDecl? ')' config=RuleConfig?;
+
+type JustificationOrTemplate = Justification | Template;
 
 type Body = JustificationBody | TemplateBody
 
@@ -49,7 +54,7 @@ QualifiedRef returns string:
     ID (':' ID)*;
 
 ParamsDecl:
-    ids+=QualifiedId (',' ids+=QualifiedId)*;
+    refs+=[JustificationOrTemplate:QualifiedRef] (',' refs+=[JustificationOrTemplate:QualifiedRef])*;
 
 RuleConfig:
     '{' entries+=KeyValDecl+ '}';

--- a/packages/language/test/completion.test.ts
+++ b/packages/language/test/completion.test.ts
@@ -247,7 +247,7 @@ describe('Relation from/to completion', () => {
 
 describe('Operator completion', () => {
 
-    test('suggests local justification and template names after "is"', async () => {
+    test('suggests known operator names after "is" (not justification/template names)', async () => {
         await checkCompletion({
             text: `
                 template MyTemplate {
@@ -261,8 +261,10 @@ describe('Operator completion', () => {
             index: 0,
             assert: (completions) => {
                 const labels = completions.items.map(i => i.label);
-                expect(labels).toContain('MyTemplate');
-                expect(labels).toContain('MyJ');
+                expect(labels).toContain('assemble');
+                expect(labels).toContain('refine');
+                expect(labels).not.toContain('MyTemplate');
+                expect(labels).not.toContain('MyJ');
             }
         });
     });
@@ -270,19 +272,45 @@ describe('Operator completion', () => {
     test('filters operator suggestions by partial input', async () => {
         await checkCompletion({
             text: `
-                template AlphaTemplate {
-                    conclusion c is "Claim"
-                }
-                template BetaTemplate {
-                    conclusion c is "Claim"
-                }
-                justification Composed is Alpha<|>
+                justification Composed is ass<|>
             `,
             index: 0,
             assert: (completions) => {
                 const labels = completions.items.map(i => i.label);
-                expect(labels).toContain('AlphaTemplate');
-                expect(labels).not.toContain('BetaTemplate');
+                expect(labels).toContain('assemble');
+                expect(labels).not.toContain('refine');
+            }
+        });
+    });
+
+    test('suggests config keys for assemble operator', async () => {
+        await checkCompletion({
+            text: `
+                justification A { conclusion c is "C" }
+                justification Composed is assemble(A) { <|>
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('conclusionLabel');
+                expect(labels).toContain('strategyLabel');
+                expect(labels).not.toContain('hook');
+            }
+        });
+    });
+
+    test('suggests config keys for refine operator', async () => {
+        await checkCompletion({
+            text: `
+                template T { conclusion c is "C" }
+                justification Composed is refine(T) { <|>
+            `,
+            index: 0,
+            assert: (completions) => {
+                const labels = completions.items.map(i => i.label);
+                expect(labels).toContain('hook');
+                expect(labels).not.toContain('conclusionLabel');
+                expect(labels).not.toContain('strategyLabel');
             }
         });
     });

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -126,10 +126,10 @@ describe('Parsing tests', () => {
         expect(isJustification(j)).toBe(true);
         if (!isJustification(j)) return;
         expect(j.contents).toBeUndefined();
-        expect(j.operator?.parts).toEqual(['refine']);
-        expect(j.params?.ids).toHaveLength(1);
-        expect(j.config?.entries).toHaveLength(1);
-        expect(j.config?.entries[0].key).toBe('mapping');
+        expect(j.composition?.operator).toBe('refine');
+        expect(j.composition?.params?.refs).toHaveLength(1);
+        expect(j.composition?.config?.entries).toHaveLength(1);
+        expect(j.composition?.config?.entries[0].key).toBe('mapping');
     });
 
     test('parse load without alias', async () => {

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -234,4 +234,56 @@ describe('Validation tests', () => {
         const messages = diagnosticMessages(doc);
         expect(messages.some(m => m.includes("Expected element with id 'T:abs'"))).toBe(true);
     });
+
+    test('unknown composition operator triggers error', async () => {
+        const doc = await parse(`
+            justification A { conclusion c is "C" }
+            justification Composed is unknown(A) {
+                conclusionLabel: "C"
+                strategyLabel: "S"
+            }
+        `);
+        assertNoParseErrors(doc);
+        const messages = diagnosticMessages(doc);
+        expect(messages.some(m => m.includes("Unknown operator 'unknown'"))).toBe(true);
+    });
+
+    test('unknown config key triggers error', async () => {
+        const doc = await parse(`
+            justification A { conclusion c is "C" }
+            justification Composed is assemble(A) {
+                conclusionLabel: "C"
+                strategyLabel: "S"
+                wrongKey: "X"
+            }
+        `);
+        assertNoParseErrors(doc);
+        const messages = diagnosticMessages(doc);
+        expect(messages.some(m => m.includes("Unknown config key 'wrongKey'"))).toBe(true);
+    });
+
+    test('missing required config key triggers error', async () => {
+        const doc = await parse(`
+            justification A { conclusion c is "C" }
+            justification Composed is assemble(A) {
+                conclusionLabel: "C"
+            }
+        `);
+        assertNoParseErrors(doc);
+        const messages = diagnosticMessages(doc);
+        expect(messages.some(m => m.includes("Missing required config key 'strategyLabel'"))).toBe(true);
+    });
+
+    test('valid assemble composition passes validation', async () => {
+        const doc = await parse(`
+            justification A { conclusion c is "C" }
+            justification Composed is assemble(A) {
+                conclusionLabel: "C"
+                strategyLabel: "S"
+            }
+        `);
+        assertNoParseErrors(doc);
+        const messages = diagnosticMessages(doc);
+        expect(messages.some(m => m.includes('operator') || m.includes('config key'))).toBe(false);
+    });
 });


### PR DESCRIPTION
This pull request introduces significant improvements to the composition operator feature in the jPipe language, including grammar refactoring, enhanced code completion, improved scope resolution, and robust validation for composition operators and their configuration keys. The changes make the handling of operators like `assemble` and `refine` more structured, user-friendly, and error-resistant.

**Grammar and AST Refactoring**
- Refactored the grammar to introduce a new `Composition` AST node, separating operator-based definitions from body-based ones for both `Justification` and `Template`. The `ParamsDecl` rule now references other justifications or templates directly. [[1]](diffhunk://#diff-a749d82b7bcfa6eff8b7a5919589fb8d2372f17c1d4e4949303c85b8c70ad894L11-R20) [[2]](diffhunk://#diff-a749d82b7bcfa6eff8b7a5919589fb8d2372f17c1d4e4949303c85b8c70ad894L52-R57)

**Completion and Scope Improvements**
- Enhanced the completion provider to offer context-aware suggestions for composition operators and their config keys, with fuzzy matching and snippet support. Operator and config key completions are now based on a known set, and completion logic is simplified and more robust. [[1]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L312-R318) [[2]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L332-R360)
- Improved scope provider logic to handle the new composition structure, ensuring correct resolution for `parent`, `refs`, `from`, and `to` properties, and supporting namespace-aware imports.

**Validation Enhancements**
- Added validation checks to ensure only known operators are accepted and that config keys are both allowed and required as appropriate for each operator. Errors are reported for unknown operators, unknown keys, or missing required keys. [[1]](diffhunk://#diff-deea0014a64074b4b6ad86171f3929a669f5e2149918c5dceac8f3996b0758a3R33) [[2]](diffhunk://#diff-deea0014a64074b4b6ad86171f3929a669f5e2149918c5dceac8f3996b0758a3R48-R93)

**Import and Utility Updates**
- Added utility to retrieve imported justifications and templates with their namespaces, supporting the new scope and completion logic.

**Other Notable Changes**
- Streamlined and clarified code for candidate filtering and error handling in the completion provider, and updated imports for consistency. [[1]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R120-R127) [[2]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L158-R180) [[3]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L31-R31) [[4]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L10-R10) [[5]](diffhunk://#diff-0fd9289ebaa622126547964e8c3d99d79f213606b2ec92c7fbc670240e91c518R9) [[6]](diffhunk://#diff-deea0014a64074b4b6ad86171f3929a669f5e2149918c5dceac8f3996b0758a3R5)

**References:**  
[[1]](diffhunk://#diff-a749d82b7bcfa6eff8b7a5919589fb8d2372f17c1d4e4949303c85b8c70ad894L11-R20) [[2]](diffhunk://#diff-a749d82b7bcfa6eff8b7a5919589fb8d2372f17c1d4e4949303c85b8c70ad894L52-R57) [[3]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L312-R318) [[4]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L332-R360) [[5]](diffhunk://#diff-0bb15518fc69a68af5ca5f4da3b0f55b34635c5561f5b7c1c9dbb3055b83fe8eR31-R79) [[6]](diffhunk://#diff-deea0014a64074b4b6ad86171f3929a669f5e2149918c5dceac8f3996b0758a3R33) [[7]](diffhunk://#diff-deea0014a64074b4b6ad86171f3929a669f5e2149918c5dceac8f3996b0758a3R48-R93) [[8]](diffhunk://#diff-0fd9289ebaa622126547964e8c3d99d79f213606b2ec92c7fbc670240e91c518R120-R138) [[9]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027R120-R127) [[10]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L158-R180) [[11]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L31-R31) [[12]](diffhunk://#diff-1caffbf8fcbeeeda925f0e09150a36365f498246626ed2eae4f17878e9211027L10-R10) [[13]](diffhunk://#diff-0fd9289ebaa622126547964e8c3d99d79f213606b2ec92c7fbc670240e91c518R9) [[14]](diffhunk://#diff-deea0014a64074b4b6ad86171f3929a669f5e2149918c5dceac8f3996b0758a3R5)