### PR TITLE
Enhance jPipe with context menu grouping, hover labels, and logging

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -104,6 +104,12 @@
                 "icon": "$(check)"
             }
         ],
+        "submenus": [
+            {
+                "id": "jpipe.submenu",
+                "label": "jPipe"
+            }
+        ],
         "menus": {
             "editor/title": [
                 {
@@ -114,44 +120,43 @@
             ],
             "editor/context": [
                 {
-                    "command": "jpipe.vis.preview",
+                    "submenu": "jpipe.submenu",
                     "when": "resourceLangId == jpipe",
                     "group": "navigation"
+                }
+            ],
+            "jpipe.submenu": [
+                {
+                    "command": "jpipe.vis.preview",
+                    "group": "1_view@1"
                 },
                 {
                     "command": "jpipe.downloadSVG",
-                    "when": "resourceLangId == jpipe",
-                    "group": "navigation"
+                    "group": "2_download@1"
                 },
                 {
                     "command": "jpipe.downloadPNG",
-                    "when": "resourceLangId == jpipe",
-                    "group": "navigation"
+                    "group": "2_download@2"
                 },
                 {
                     "command": "jpipe.downloadJSON",
-                    "when": "resourceLangId == jpipe",
-                    "group": "navigation"
+                    "group": "2_download@3"
                 },
                 {
                     "command": "jpipe.downloadJPEG",
-                    "when": "resourceLangId == jpipe",
-                    "group": "navigation"
+                    "group": "2_download@4"
                 },
                 {
                     "command": "jpipe.downloadDOT",
-                    "when": "resourceLangId == jpipe",
-                    "group": "navigation"
+                    "group": "2_download@5"
                 },
                 {
                     "command": "jpipe.downloadPython",
-                    "when": "resourceLangId == jpipe",
-                    "group": "navigation"
+                    "group": "2_download@6"
                 },
                 {
                     "command": "jpipe.downloadJPIPE",
-                    "when": "resourceLangId == jpipe",
-                    "group": "navigation"
+                    "group": "2_download@7"
                 }
             ]
         },

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -48,6 +48,45 @@
                 "path": "syntaxes/jpipe.tmLanguage.json"
             }
         ],
+        "semanticTokenTypes": [
+            {
+                "id": "jpipe-load",
+                "superType": "keyword",
+                "description": "Import keyword (load)"
+            },
+            {
+                "id": "jpipe-structure",
+                "superType": "keyword",
+                "description": "Structural keywords (justification, template, implements)"
+            },
+            {
+                "id": "jpipe-relation",
+                "superType": "keyword",
+                "description": "Relation keyword (supports)"
+            },
+            {
+                "id": "jpipe-abstract",
+                "superType": "keyword",
+                "description": "Abstract element keyword (@support)"
+            },
+            {
+                "id": "jpipe-element",
+                "superType": "keyword",
+                "description": "Element keywords (conclusion, evidence, strategy, sub-conclusion)"
+            }
+        ],
+        "semanticTokenScopes": [
+            {
+                "language": "jpipe",
+                "scopes": {
+                    "jpipe-load": ["keyword.control.import.jpipe"],
+                    "jpipe-structure": ["storage.type.jpipe"],
+                    "jpipe-relation": ["keyword.operator.jpipe"],
+                    "jpipe-abstract": ["storage.modifier.jpipe"],
+                    "jpipe-element": ["entity.name.type.jpipe"]
+                }
+            }
+        ],
         "commands": [
             {
                 "command": "jpipe.vis.preview",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -51,12 +51,12 @@
         "semanticTokenTypes": [
             {
                 "id": "jpipe-load",
-                "superType": "keyword",
+                "superType": "namespace",
                 "description": "Import keyword (load)"
             },
             {
                 "id": "jpipe-structure",
-                "superType": "keyword",
+                "superType": "type",
                 "description": "Structural keywords (justification, template, implements)"
             },
             {
@@ -79,11 +79,11 @@
             {
                 "language": "jpipe",
                 "scopes": {
-                    "jpipe-load": ["keyword.control.import.jpipe"],
-                    "jpipe-structure": ["storage.type.jpipe"],
-                    "jpipe-relation": ["keyword.operator.jpipe"],
+                    "jpipe-load": ["entity.name.namespace.jpipe"],
+                    "jpipe-structure": ["support.type.jpipe"],
+                    "jpipe-relation": ["variable.other.enummember.jpipe"],
                     "jpipe-abstract": ["storage.modifier.jpipe"],
-                    "jpipe-element": ["entity.name.type.jpipe"]
+                    "jpipe-element": ["entity.name.function.jpipe"]
                 }
             }
         ],

--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -115,7 +115,7 @@ export class ImageGenerator {
             command += ` -o "${outputPath.fsPath}"`;
         }
 
-        this.logger.debug(`Executing: ${command}`);
+        this.logger.info(`Executing: ${command}`);
 
         try {
             const { stdout } = await execAsync(command);
@@ -203,7 +203,7 @@ export class ImageGenerator {
             command = `"${cliCmd}" diagnostic ${inputArg}`;
         }
 
-        this.logger.debug(`Executing: ${command}`);
+        this.logger.info(`Executing: ${command}`);
         try {
             const { stdout, stderr } = await execAsync(command, { env: envWithPath() });
             return [stdout, stderr].filter(Boolean).join('\n').trim() || '(no output)';
@@ -228,12 +228,18 @@ export class ImageGenerator {
     
     private logGenerationError(diagramName: string, error: any): void {
         const exitCode: number | undefined = typeof error?.code === 'number' ? error.code : undefined;
+        const stderr = typeof error?.stderr === 'string' ? error.stderr.trim() : '';
         if (exitCode === 1) {
             this.logger.warn(`Compiler exit 1 (model errors) for '${diagramName}'`);
         } else if (exitCode === 42) {
             this.logger.error(`Compiler exit 42 (crash) for '${diagramName}'`);
+            this.logger.reveal();
         } else {
             this.logger.error(`Generation failed for '${diagramName}': ${error instanceof Error ? error.message : String(exitCode ?? error)}`);
+            this.logger.reveal();
+        }
+        if (stderr) {
+            this.logger.warn(`Compiler stderr: ${stderr}`);
         }
     }
 

--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -47,10 +47,11 @@ export class ImageGenerator {
     public async generate(
         saveToFile: boolean = false,
         format: ImageFormat = ImageFormat.SVG,
-        document?: vscode.TextDocument
+        document?: vscode.TextDocument,
+        forcedDiagramName?: string
     ): Promise<string> {
         let editor = vscode.window.activeTextEditor;
-        
+
         // Use provided document or get from active editor
         if (!document) {
             if (!editor || editor.document.languageId !== 'jpipe') {
@@ -58,14 +59,14 @@ export class ImageGenerator {
             }
             document = editor.document;
         }
-        
+
         // If we don't have an editor, try to get one from visible text editors
         if (!editor) {
             editor = vscode.window.visibleTextEditors.find(e => e.document === document);
         }
 
         const inputFile = document.uri.fsPath;
-        const diagramName = this.findDiagramName(document, editor);
+        const diagramName = forcedDiagramName ?? this.findDiagramName(document, editor);
         
         const config = vscode.workspace.getConfiguration('jpipe');
         const mode = config.get<string>('executionMode', 'cli');
@@ -214,9 +215,9 @@ export class ImageGenerator {
         }
     }
 
-    public async generateAndSave(format: ImageFormat = ImageFormat.SVG, document?: vscode.TextDocument): Promise<void> {
+    public async generateAndSave(format: ImageFormat = ImageFormat.SVG, document?: vscode.TextDocument, forcedDiagramName?: string): Promise<void> {
         try {
-            await this.generate(true, format, document);
+            await this.generate(true, format, document, forcedDiagramName);
             vscode.window.showInformationMessage(`${format} saved successfully`);
         } catch (error: any) {
             if (error?.cancelled === true || String(error?.message ?? '') === 'Save cancelled') {

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -44,10 +44,6 @@ export class PreviewProvider {
             PreviewProvider.webviewPanel = this.createWebviewPanel();
             PreviewProvider.webviewDisposed = false;
             this.logger.info('Webview panel created');
-            // Focus the panel group, lock it, then restore focus to the editor
-            PreviewProvider.webviewPanel.reveal(vscode.ViewColumn.Beside, false);
-            await vscode.commands.executeCommand('workbench.action.lockEditorGroup');
-            PreviewProvider.webviewPanel.reveal(vscode.ViewColumn.Beside, true);
         } else {
             PreviewProvider.webviewPanel.reveal(vscode.ViewColumn.Beside, true);
         }
@@ -342,9 +338,6 @@ export class PreviewProvider {
         const diagramNameJson = diagramName != null ? JSON.stringify(diagramName) : 'null';
         const renderJson = render ? JSON.stringify(render) : 'null';
         const unsavedJson = unsaved ? 'true' : 'false';
-        const iconUri = PreviewProvider.webviewPanel!.webview.asWebviewUri(
-            vscode.Uri.joinPath(this.context.extensionUri, 'images', 'icon_light.svg')
-        );
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -544,7 +537,7 @@ export class PreviewProvider {
 <body>
     <div id="toolbar">
         <div id="brand">
-            <a href="#" id="jpipe-link" title="Open jpipe.org"><img src="${iconUri}" alt="jPipe" style="height:22px;width:auto;vertical-align:middle;"></a>
+            <a href="#" id="jpipe-link" title="Open jpipe.org">JPIPE</a>
         </div>
         <div id="toolbar-right">
             <div class="toolbar-group download-wrap">
@@ -771,9 +764,6 @@ export class PreviewProvider {
             .replaceAll('<', '&lt;')
             .replaceAll('>', '&gt;');
         const unsavedJson = unsaved ? 'true' : 'false';
-        const iconUri = PreviewProvider.webviewPanel!.webview.asWebviewUri(
-            vscode.Uri.joinPath(this.context.extensionUri, 'images', 'icon_light.svg')
-        );
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -874,7 +864,7 @@ export class PreviewProvider {
 <body>
     <div id="toolbar">
         <div id="brand">
-            <a href="#" id="jpipe-link" title="Open jpipe.org"><img src="${iconUri}" alt="jPipe" style="height:22px;width:auto;vertical-align:middle;"></a>
+            <a href="#" id="jpipe-link" title="Open jpipe.org">JPIPE</a>
         </div>
         <div>
             <button class="toolbar-btn active" id="mode-toggle" data-tooltip="Back to diagram view"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="6.5" cy="6.5" r="4"/><line x1="10" y1="10" x2="14" y2="14"/></svg></button>

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -41,9 +41,11 @@ export class PreviewProvider {
         }
 
         if (PreviewProvider.webviewDisposed || !PreviewProvider.webviewPanel) {
+            const previousColumn = editor.viewColumn ?? vscode.ViewColumn.One;
             PreviewProvider.webviewPanel = this.createWebviewPanel();
             PreviewProvider.webviewDisposed = false;
             this.logger.info('Webview panel created');
+            await this.lockPreviewGroup(previousColumn);
         } else {
             PreviewProvider.webviewPanel.reveal(vscode.ViewColumn.Beside, true);
         }
@@ -52,6 +54,27 @@ export class PreviewProvider {
         await this.updatePreview(editor.document, editor);
     }
     
+    private async lockPreviewGroup(restoreColumn: vscode.ViewColumn): Promise<void> {
+        const columnNames = ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth'];
+        // Give VS Code one tick to register the new panel in tabGroups
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        const group = vscode.window.tabGroups.all.find(g =>
+            g.tabs.some(t =>
+                t.input instanceof vscode.TabInputWebview &&
+                (t.input as vscode.TabInputWebview).viewType === 'jpipe.preview'
+            )
+        );
+        if (!group) return;
+        const colIndex = (group.viewColumn as number) - 1;
+        if (colIndex < 0 || colIndex >= columnNames.length) return;
+        await vscode.commands.executeCommand(`workbench.action.focus${columnNames[colIndex]}EditorGroup`);
+        await vscode.commands.executeCommand('workbench.action.lockEditorGroup');
+        const restoreIndex = (restoreColumn as number) - 1;
+        if (restoreIndex >= 0 && restoreIndex < columnNames.length) {
+            await vscode.commands.executeCommand(`workbench.action.focus${columnNames[restoreIndex]}EditorGroup`);
+        }
+    }
+
     private setupEventListeners(context: vscode.ExtensionContext): void {
         const saveListener = vscode.workspace.onDidSaveTextDocument((document) => {
             if (document.languageId !== 'jpipe' || !PreviewProvider.webviewPanel || PreviewProvider.webviewDisposed) return;

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -146,6 +146,9 @@ export class PreviewProvider {
         try {
             diagramName = this.imageGenerator.findDiagramName(document, editor);
         } catch {
+            if (!this.lastGoodHtml) {
+                PreviewProvider.webviewPanel.webview.html = this.getNodiagramHtml();
+            }
             return;
         }
 
@@ -204,6 +207,7 @@ export class PreviewProvider {
                     vscode.window.showErrorMessage(msg ? `jPipe Error: ${msg}` : 'jPipe Error: render failed');
                 }
                 this.lastRenderedDocumentUri = document.uri.toString();
+                this.lastRenderedDiagramName = diagramName;
             } else {
                 if (exitCode === 1) {
                     vscode.window.showWarningMessage(`jPipe: model has errors (exit code 1): ${cleanMsg}`);
@@ -219,6 +223,7 @@ export class PreviewProvider {
                     PreviewProvider.webviewPanel.webview.html = this.getLoadingHtml();
                 }
                 this.lastRenderedDocumentUri = undefined;
+                this.lastRenderedDiagramName = undefined;
             }
         }
     }
@@ -325,7 +330,8 @@ export class PreviewProvider {
                 const fmt = (ImageFormat as Record<string, ImageFormat>)[msg.format];
                 if (fmt !== undefined) {
                     const activeDoc = vscode.window.activeTextEditor?.document;
-                    if (activeDoc?.languageId === 'jpipe') {
+                    if (activeDoc?.languageId === 'jpipe'
+                            && activeDoc.uri.toString() === this.lastRenderedDocumentUri) {
                         this.imageGenerator.generateAndSave(fmt, activeDoc);
                         return;
                     }
@@ -943,6 +949,40 @@ export class PreviewProvider {
             } catch (err) {}
         })();
     </script>
+</body>
+</html>`;
+    }
+
+    private getNodiagramHtml(): string {
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>jPipe Preview</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 24px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            box-sizing: border-box;
+            background-color: var(--vscode-editor-background);
+            color: var(--vscode-foreground);
+            font-family: var(--vscode-font-family);
+        }
+        .message {
+            max-width: 32rem;
+            text-align: center;
+            opacity: 0.8;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+    <div class="message">Move the cursor into a diagram block to preview it.</div>
 </body>
 </html>`;
     }

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -19,10 +19,14 @@ export class PreviewProvider {
     private lastRenderedDiagramName: string | undefined;
     private lastGoodHtml: string | undefined;
 
+    public getLastRenderedDocumentUri(): string | undefined {
+        return this.lastRenderedDocumentUri;
+    }
+
     constructor(
         private readonly imageGenerator: ImageGenerator,
         private readonly languageClient: LanguageClient,
-        context: vscode.ExtensionContext,
+        private readonly context: vscode.ExtensionContext,
         private readonly logger: JpipeLogger
     ) {
         this.setupEventListeners(context);
@@ -40,6 +44,10 @@ export class PreviewProvider {
             PreviewProvider.webviewPanel = this.createWebviewPanel();
             PreviewProvider.webviewDisposed = false;
             this.logger.info('Webview panel created');
+            // Focus the panel group, lock it, then restore focus to the editor
+            PreviewProvider.webviewPanel.reveal(vscode.ViewColumn.Beside, false);
+            await vscode.commands.executeCommand('workbench.action.lockEditorGroup');
+            PreviewProvider.webviewPanel.reveal(vscode.ViewColumn.Beside, true);
         } else {
             PreviewProvider.webviewPanel.reveal(vscode.ViewColumn.Beside, true);
         }
@@ -265,9 +273,15 @@ export class PreviewProvider {
             },
             {
                 enableScripts: true,
-                retainContextWhenHidden: true
+                retainContextWhenHidden: true,
+                localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'images')]
             }
         );
+
+        panel.iconPath = {
+            light: vscode.Uri.joinPath(this.context.extensionUri, 'images', 'icon_light.svg'),
+            dark:  vscode.Uri.joinPath(this.context.extensionUri, 'images', 'icon_dark.svg')
+        };
         
         panel.onDidDispose(() => {
             PreviewProvider.webviewPanel = undefined;
@@ -328,6 +342,9 @@ export class PreviewProvider {
         const diagramNameJson = diagramName != null ? JSON.stringify(diagramName) : 'null';
         const renderJson = render ? JSON.stringify(render) : 'null';
         const unsavedJson = unsaved ? 'true' : 'false';
+        const iconUri = PreviewProvider.webviewPanel!.webview.asWebviewUri(
+            vscode.Uri.joinPath(this.context.extensionUri, 'images', 'icon_light.svg')
+        );
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -527,7 +544,7 @@ export class PreviewProvider {
 <body>
     <div id="toolbar">
         <div id="brand">
-            <a href="#" id="jpipe-link" title="Open jpipe.org">JPIPE</a>
+            <a href="#" id="jpipe-link" title="Open jpipe.org"><img src="${iconUri}" alt="jPipe" style="height:22px;width:auto;vertical-align:middle;"></a>
         </div>
         <div id="toolbar-right">
             <div class="toolbar-group download-wrap">
@@ -754,6 +771,9 @@ export class PreviewProvider {
             .replaceAll('<', '&lt;')
             .replaceAll('>', '&gt;');
         const unsavedJson = unsaved ? 'true' : 'false';
+        const iconUri = PreviewProvider.webviewPanel!.webview.asWebviewUri(
+            vscode.Uri.joinPath(this.context.extensionUri, 'images', 'icon_light.svg')
+        );
         return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -854,7 +874,7 @@ export class PreviewProvider {
 <body>
     <div id="toolbar">
         <div id="brand">
-            <a href="#" id="jpipe-link" title="Open jpipe.org">JPIPE</a>
+            <a href="#" id="jpipe-link" title="Open jpipe.org"><img src="${iconUri}" alt="jPipe" style="height:22px;width:auto;vertical-align:middle;"></a>
         </div>
         <div>
             <button class="toolbar-btn active" id="mode-toggle" data-tooltip="Back to diagram view"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="6.5" cy="6.5" r="4"/><line x1="10" y1="10" x2="14" y2="14"/></svg></button>

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -23,6 +23,10 @@ export class PreviewProvider {
         return this.lastRenderedDocumentUri;
     }
 
+    public getLastRenderedDiagramName(): string | undefined {
+        return this.lastRenderedDiagramName;
+    }
+
     constructor(
         private readonly imageGenerator: ImageGenerator,
         private readonly languageClient: LanguageClient,
@@ -56,17 +60,13 @@ export class PreviewProvider {
     
     private async lockPreviewGroup(restoreColumn: vscode.ViewColumn): Promise<void> {
         const columnNames = ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh', 'Eighth', 'Ninth'];
-        // Give VS Code one tick to register the new panel in tabGroups
-        await new Promise<void>(resolve => setTimeout(resolve, 0));
-        const group = vscode.window.tabGroups.all.find(g =>
-            g.tabs.some(t =>
-                t.input instanceof vscode.TabInputWebview &&
-                (t.input as vscode.TabInputWebview).viewType === 'jpipe.preview'
-            )
-        );
-        if (!group) return;
-        const colIndex = (group.viewColumn as number) - 1;
-        if (colIndex < 0 || colIndex >= columnNames.length) return;
+        // Wait for VS Code to resolve ViewColumn.Beside to an actual column number on panel.viewColumn
+        await new Promise<void>(resolve => setTimeout(resolve, 100));
+        const panelColumn = PreviewProvider.webviewPanel?.viewColumn;
+        if (panelColumn === undefined || (panelColumn as number) <= 0) return;
+        const colIndex = (panelColumn as number) - 1;
+        if (colIndex >= columnNames.length) return;
+        // Use executeCommand for focus so we can await it (panel.reveal() is fire-and-forget)
         await vscode.commands.executeCommand(`workbench.action.focus${columnNames[colIndex]}EditorGroup`);
         await vscode.commands.executeCommand('workbench.action.lockEditorGroup');
         const restoreIndex = (restoreColumn as number) - 1;
@@ -318,10 +318,11 @@ export class PreviewProvider {
                         return;
                     }
                     const lastUri = this.lastRenderedDocumentUri;
+                    const lastDiagramName = this.lastRenderedDiagramName;
                     if (lastUri) {
                         vscode.workspace.openTextDocument(vscode.Uri.parse(lastUri))
                             .then(
-                                doc => this.imageGenerator.generateAndSave(fmt, doc),
+                                doc => this.imageGenerator.generateAndSave(fmt, doc, lastDiagramName),
                                 () => this.imageGenerator.generateAndSave(fmt)
                             );
                         return;

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -130,20 +130,35 @@ export class PreviewProvider {
     private async updatePreview(document: vscode.TextDocument, editor: vscode.TextEditor | undefined): Promise<void> {
         if (!PreviewProvider.webviewPanel) return;
 
-        try {
-            if (this.viewMode === 'diagnostic') {
+        // Diagnostic mode bypasses diagram-name resolution
+        if (this.viewMode === 'diagnostic') {
+            try {
                 const output = await this.imageGenerator.generateDiagnostic(document);
                 PreviewProvider.webviewPanel.webview.html = this.getHtmlForDiagnostic(output, this.unsaved);
-                return;
-            }
+            } catch { /* ignore diagnostic errors */ }
+            return;
+        }
+
+        // Resolve diagram name using the caller's editor (correct cursor context).
+        // If the cursor is outside any diagram block, bail out silently so the
+        // current preview stays visible and no error notification is shown.
+        let diagramName: string;
+        try {
+            diagramName = this.imageGenerator.findDiagramName(document, editor);
+        } catch {
+            return;
+        }
+
+        try {
             // Avoid blanking the whole preview on transient render errors:
             // only show a full loading screen if we have nothing rendered yet.
             if (!this.lastGoodHtml) {
                 PreviewProvider.webviewPanel.webview.html = this.getLoadingHtml();
             }
-            let svg = await this.imageGenerator.generate(false, ImageFormat.SVG, document);
+            // Pass the pre-resolved diagramName so generate() does not re-derive
+            // it from activeTextEditor (which may have a different cursor position).
+            let svg = await this.imageGenerator.generate(false, ImageFormat.SVG, document, diagramName);
             svg = this.extractSvgFromOutput(svg);
-            const diagramName = this.imageGenerator.findDiagramName(document, editor);
             this.logger.debug(`Preview updated: '${diagramName}' in ${document.fileName}`);
             let highlightName = await this.getSymbolNameAtCursor(document, editor);
             if (highlightName === diagramName) highlightName = null;
@@ -166,9 +181,6 @@ export class PreviewProvider {
 
             const svgFromError = this.extractSvgFromOutput(stdout);
             const hasSvg = svgFromError.includes('<svg');
-            const diagramName = (() => {
-                try { return this.imageGenerator.findDiagramName(document, editor); } catch { return undefined; }
-            })();
             let highlightName = await this.getSymbolNameAtCursor(document, editor);
             if (highlightName === diagramName) highlightName = null;
 

--- a/packages/extension/src/extension/logger.ts
+++ b/packages/extension/src/extension/logger.ts
@@ -31,6 +31,8 @@ export class JpipeLogger {
     warn(msg: string):  void { this.write(2, 'WARN ', msg); }
     error(msg: string): void { this.write(1, 'ERROR', msg); }
 
+    reveal(): void { this.channel.show(true); }
+
     private write(rank: number, label: string, msg: string): void {
         if (rank > this.rank) return;
         this.channel.appendLine(`${new Date().toISOString()} [${label}] ${msg}`);

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -19,14 +19,25 @@ export function activate(context: vscode.ExtensionContext): void {
     const imageGenerator = new ImageGenerator(logger);
     const previewProvider = new PreviewProvider(imageGenerator, client, context, logger);
 
+    async function resolveDocumentForExport(): Promise<vscode.TextDocument | undefined> {
+        const active = vscode.window.activeTextEditor?.document;
+        if (active?.languageId === 'jpipe') return active;
+        const lastUri = previewProvider.getLastRenderedDocumentUri();
+        if (lastUri) {
+            try { return await vscode.workspace.openTextDocument(vscode.Uri.parse(lastUri)); }
+            catch { /* fall through */ }
+        }
+        return undefined;
+    }
+
     context.subscriptions.push(
-        vscode.commands.registerCommand('jpipe.downloadPNG',    () => imageGenerator.generateAndSave(ImageFormat.PNG)),
-        vscode.commands.registerCommand('jpipe.downloadSVG',    () => imageGenerator.generateAndSave(ImageFormat.SVG)),
-        vscode.commands.registerCommand('jpipe.downloadJSON',   () => imageGenerator.generateAndSave(ImageFormat.JSON)),
-        vscode.commands.registerCommand('jpipe.downloadJPEG',   () => imageGenerator.generateAndSave(ImageFormat.JPEG)),
-        vscode.commands.registerCommand('jpipe.downloadDOT',    () => imageGenerator.generateAndSave(ImageFormat.DOT)),
-        vscode.commands.registerCommand('jpipe.downloadPython', () => imageGenerator.generateAndSave(ImageFormat.PYTHON)),
-        vscode.commands.registerCommand('jpipe.downloadJPIPE',  () => imageGenerator.generateAndSave(ImageFormat.JPIPE)),
+        vscode.commands.registerCommand('jpipe.downloadPNG',    async () => imageGenerator.generateAndSave(ImageFormat.PNG,    await resolveDocumentForExport())),
+        vscode.commands.registerCommand('jpipe.downloadSVG',    async () => imageGenerator.generateAndSave(ImageFormat.SVG,    await resolveDocumentForExport())),
+        vscode.commands.registerCommand('jpipe.downloadJSON',   async () => imageGenerator.generateAndSave(ImageFormat.JSON,   await resolveDocumentForExport())),
+        vscode.commands.registerCommand('jpipe.downloadJPEG',   async () => imageGenerator.generateAndSave(ImageFormat.JPEG,   await resolveDocumentForExport())),
+        vscode.commands.registerCommand('jpipe.downloadDOT',    async () => imageGenerator.generateAndSave(ImageFormat.DOT,    await resolveDocumentForExport())),
+        vscode.commands.registerCommand('jpipe.downloadPython', async () => imageGenerator.generateAndSave(ImageFormat.PYTHON, await resolveDocumentForExport())),
+        vscode.commands.registerCommand('jpipe.downloadJPIPE',  async () => imageGenerator.generateAndSave(ImageFormat.JPIPE,  await resolveDocumentForExport())),
         vscode.commands.registerCommand('jpipe.vis.preview', () => previewProvider.openPreview()),
         vscode.commands.registerCommand('jpipe.checkInstallation', async () => {
             const { ok, message } = await imageGenerator.check();

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -19,25 +19,28 @@ export function activate(context: vscode.ExtensionContext): void {
     const imageGenerator = new ImageGenerator(logger);
     const previewProvider = new PreviewProvider(imageGenerator, client, context, logger);
 
-    async function resolveDocumentForExport(): Promise<vscode.TextDocument | undefined> {
+    async function resolveExportContext(): Promise<{ doc: vscode.TextDocument | undefined; diagramName: string | undefined }> {
         const active = vscode.window.activeTextEditor?.document;
-        if (active?.languageId === 'jpipe') return active;
+        if (active?.languageId === 'jpipe') return { doc: active, diagramName: undefined };
         const lastUri = previewProvider.getLastRenderedDocumentUri();
+        const lastDiagramName = previewProvider.getLastRenderedDiagramName();
         if (lastUri) {
-            try { return await vscode.workspace.openTextDocument(vscode.Uri.parse(lastUri)); }
-            catch { /* fall through */ }
+            try {
+                const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(lastUri));
+                return { doc, diagramName: lastDiagramName };
+            } catch { /* fall through */ }
         }
-        return undefined;
+        return { doc: undefined, diagramName: undefined };
     }
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('jpipe.downloadPNG',    async () => imageGenerator.generateAndSave(ImageFormat.PNG,    await resolveDocumentForExport())),
-        vscode.commands.registerCommand('jpipe.downloadSVG',    async () => imageGenerator.generateAndSave(ImageFormat.SVG,    await resolveDocumentForExport())),
-        vscode.commands.registerCommand('jpipe.downloadJSON',   async () => imageGenerator.generateAndSave(ImageFormat.JSON,   await resolveDocumentForExport())),
-        vscode.commands.registerCommand('jpipe.downloadJPEG',   async () => imageGenerator.generateAndSave(ImageFormat.JPEG,   await resolveDocumentForExport())),
-        vscode.commands.registerCommand('jpipe.downloadDOT',    async () => imageGenerator.generateAndSave(ImageFormat.DOT,    await resolveDocumentForExport())),
-        vscode.commands.registerCommand('jpipe.downloadPython', async () => imageGenerator.generateAndSave(ImageFormat.PYTHON, await resolveDocumentForExport())),
-        vscode.commands.registerCommand('jpipe.downloadJPIPE',  async () => imageGenerator.generateAndSave(ImageFormat.JPIPE,  await resolveDocumentForExport())),
+        vscode.commands.registerCommand('jpipe.downloadPNG',    async () => { const { doc, diagramName } = await resolveExportContext(); imageGenerator.generateAndSave(ImageFormat.PNG,    doc, diagramName); }),
+        vscode.commands.registerCommand('jpipe.downloadSVG',    async () => { const { doc, diagramName } = await resolveExportContext(); imageGenerator.generateAndSave(ImageFormat.SVG,    doc, diagramName); }),
+        vscode.commands.registerCommand('jpipe.downloadJSON',   async () => { const { doc, diagramName } = await resolveExportContext(); imageGenerator.generateAndSave(ImageFormat.JSON,   doc, diagramName); }),
+        vscode.commands.registerCommand('jpipe.downloadJPEG',   async () => { const { doc, diagramName } = await resolveExportContext(); imageGenerator.generateAndSave(ImageFormat.JPEG,   doc, diagramName); }),
+        vscode.commands.registerCommand('jpipe.downloadDOT',    async () => { const { doc, diagramName } = await resolveExportContext(); imageGenerator.generateAndSave(ImageFormat.DOT,    doc, diagramName); }),
+        vscode.commands.registerCommand('jpipe.downloadPython', async () => { const { doc, diagramName } = await resolveExportContext(); imageGenerator.generateAndSave(ImageFormat.PYTHON, doc, diagramName); }),
+        vscode.commands.registerCommand('jpipe.downloadJPIPE',  async () => { const { doc, diagramName } = await resolveExportContext(); imageGenerator.generateAndSave(ImageFormat.JPIPE,  doc, diagramName); }),
         vscode.commands.registerCommand('jpipe.vis.preview', () => previewProvider.openPreview()),
         vscode.commands.registerCommand('jpipe.checkInstallation', async () => {
             const { ok, message } = await imageGenerator.check();

--- a/packages/language/src/jpipe-hover-provider.ts
+++ b/packages/language/src/jpipe-hover-provider.ts
@@ -1,0 +1,26 @@
+import { AstNodeHoverProvider } from 'langium/lsp';
+import type { AstNode, MaybePromise } from 'langium';
+import type { LangiumServices } from 'langium/lsp';
+import {
+    isEvidence, isStrategy, isConclusion, isSubConclusion, isAbstractSupport,
+    isJustification, isTemplate
+} from './generated/ast.js';
+
+export class JpipeHoverProvider extends AstNodeHoverProvider {
+    constructor(services: LangiumServices) {
+        super(services);
+    }
+
+    protected getAstNodeHoverContent(node: AstNode): MaybePromise<string | undefined> {
+        if (isEvidence(node) || isStrategy(node) || isConclusion(node)
+                || isSubConclusion(node) || isAbstractSupport(node)) {
+            const kind = isSubConclusion(node) ? 'sub-conclusion' : node.$type.toLowerCase();
+            return `**${node.name}** *(${kind})*`;
+        }
+        if (isJustification(node) || isTemplate(node)) {
+            const kind = isJustification(node) ? 'justification' : 'template';
+            return `**${node.id}** *(${kind})*`;
+        }
+        return undefined;
+    }
+}

--- a/packages/language/src/jpipe-hover-provider.ts
+++ b/packages/language/src/jpipe-hover-provider.ts
@@ -1,20 +1,55 @@
 import { AstNodeHoverProvider } from 'langium/lsp';
-import type { AstNode, MaybePromise } from 'langium';
+import type { AstNode, LangiumDocument, MaybePromise } from 'langium';
+import { CstUtils, GrammarUtils } from 'langium';
 import type { LangiumServices } from 'langium/lsp';
+import type { Hover, HoverParams } from 'vscode-languageserver';
 import {
     isEvidence, isStrategy, isConclusion, isSubConclusion, isAbstractSupport,
-    isJustification, isTemplate
+    isJustification, isTemplate, isQualifiedId
 } from './generated/ast.js';
+
+function elementKind(node: AstNode): string {
+    if (isSubConclusion(node)) return 'sub-conclusion';
+    if (isAbstractSupport(node)) return '@support';
+    return node.$type.toLowerCase();
+}
 
 export class JpipeHoverProvider extends AstNodeHoverProvider {
     constructor(services: LangiumServices) {
         super(services);
     }
 
+    override async getHoverContent(document: LangiumDocument, params: HoverParams): Promise<Hover | undefined> {
+        const result = await super.getHoverContent(document, params);
+        if (result) return result;
+        // AstNodeHoverProvider resolves cross-references and self-nodes via the name provider.
+        // For jPipe element declarations (evidence/strategy/etc.), the id is a QualifiedId
+        // sub-node that the base class cannot resolve to its containing element. Walk up manually.
+        const rootCst = document.parseResult.value?.$cstNode;
+        if (!rootCst) return undefined;
+        const offset = document.textDocument.offsetAt(params.position);
+        const cstNode = CstUtils.findDeclarationNodeAtOffset(rootCst, offset, this.grammarConfig.nameRegexp);
+        if (!cstNode || cstNode.offset + cstNode.length <= offset) return undefined;
+        if (isQualifiedId(cstNode.astNode)) {
+            const content = await this.getAstNodeHoverContent(cstNode.astNode.$container as AstNode);
+            if (typeof content === 'string') {
+                return { contents: { kind: 'markdown', value: content } };
+            }
+        }
+        const astNode = cstNode.astNode;
+        if ((isJustification(astNode) || isTemplate(astNode)) && GrammarUtils.findAssignment(cstNode)?.feature === 'id') {
+            const content = await this.getAstNodeHoverContent(astNode);
+            if (typeof content === 'string') {
+                return { contents: { kind: 'markdown', value: content } };
+            }
+        }
+        return undefined;
+    }
+
     protected getAstNodeHoverContent(node: AstNode): MaybePromise<string | undefined> {
         if (isEvidence(node) || isStrategy(node) || isConclusion(node)
                 || isSubConclusion(node) || isAbstractSupport(node)) {
-            const kind = isSubConclusion(node) ? 'sub-conclusion' : node.$type.toLowerCase();
+            const kind = elementKind(node);
             return `**${node.name}** *(${kind})*`;
         }
         if (isJustification(node) || isTemplate(node)) {

--- a/packages/language/src/jpipe-module.ts
+++ b/packages/language/src/jpipe-module.ts
@@ -9,6 +9,7 @@ import { JpipeDefinitionProvider } from './jpipe-definition-provider.js';
 import { JpipeDocumentSymbolProvider } from './jpipe-symbol-provider.js';
 import { JpipeNameProvider } from './jpipe-utils.js';
 import { JpipeHoverProvider } from './jpipe-hover-provider.js';
+import { JpipeSemanticTokenProvider } from './jpipe-semantic-token-provider.js';
 import { JpipeServerLogger, type LogLevel } from './jpipe-logger.js';
 
 /**
@@ -44,7 +45,8 @@ function buildJpipeModule(logger: JpipeServerLogger): Module<JpipeServices, Part
             DefinitionProvider:     (services) => new JpipeDefinitionProvider(services),
             DocumentSymbolProvider: (services) => new JpipeDocumentSymbolProvider(services),
             CompletionProvider:     (services) => new JpipeCompletionProvider(services),
-            HoverProvider:          (services) => new JpipeHoverProvider(services)
+            HoverProvider:          (services) => new JpipeHoverProvider(services),
+            SemanticTokenProvider:  (services) => new JpipeSemanticTokenProvider(services)
         },
         logger: () => logger
     };

--- a/packages/language/src/jpipe-module.ts
+++ b/packages/language/src/jpipe-module.ts
@@ -8,6 +8,7 @@ import { JpipeCompletionProvider } from './jpipe-completion.js';
 import { JpipeDefinitionProvider } from './jpipe-definition-provider.js';
 import { JpipeDocumentSymbolProvider } from './jpipe-symbol-provider.js';
 import { JpipeNameProvider } from './jpipe-utils.js';
+import { JpipeHoverProvider } from './jpipe-hover-provider.js';
 import { JpipeServerLogger, type LogLevel } from './jpipe-logger.js';
 
 /**
@@ -42,7 +43,8 @@ function buildJpipeModule(logger: JpipeServerLogger): Module<JpipeServices, Part
         lsp: {
             DefinitionProvider:     (services) => new JpipeDefinitionProvider(services),
             DocumentSymbolProvider: (services) => new JpipeDocumentSymbolProvider(services),
-            CompletionProvider:     (services) => new JpipeCompletionProvider(services)
+            CompletionProvider:     (services) => new JpipeCompletionProvider(services),
+            HoverProvider:          (services) => new JpipeHoverProvider(services)
         },
         logger: () => logger
     };

--- a/packages/language/src/jpipe-semantic-token-provider.ts
+++ b/packages/language/src/jpipe-semantic-token-provider.ts
@@ -1,0 +1,53 @@
+import { AbstractSemanticTokenProvider, type SemanticTokenAcceptor } from 'langium/lsp';
+import type { AstNode } from 'langium';
+import type { LangiumServices } from 'langium/lsp';
+import {
+    isLoad, isJustification, isTemplate, isRelation,
+    isAbstractSupport, isEvidence, isConclusion, isStrategy, isSubConclusion
+} from './generated/ast.js';
+
+export const TOKEN_LOAD      = 'jpipe-load';
+export const TOKEN_STRUCTURE = 'jpipe-structure';
+export const TOKEN_RELATION  = 'jpipe-relation';
+export const TOKEN_ABSTRACT  = 'jpipe-abstract';
+export const TOKEN_ELEMENT   = 'jpipe-element';
+
+const CUSTOM_TOKENS = [TOKEN_LOAD, TOKEN_STRUCTURE, TOKEN_RELATION, TOKEN_ABSTRACT, TOKEN_ELEMENT] as const;
+
+export class JpipeSemanticTokenProvider extends AbstractSemanticTokenProvider {
+    constructor(services: LangiumServices) {
+        super(services);
+    }
+
+    override get tokenTypes(): Record<string, number> {
+        const standard = super.tokenTypes;
+        const base = Object.keys(standard).length;
+        const custom: Record<string, number> = {};
+        CUSTOM_TOKENS.forEach((t, i) => { custom[t] = base + i; });
+        return { ...standard, ...custom };
+    }
+
+    protected highlightElement(node: AstNode, acceptor: SemanticTokenAcceptor): void {
+        if (isLoad(node)) {
+            acceptor({ node, keyword: 'load', type: TOKEN_LOAD });
+        } else if (isJustification(node)) {
+            acceptor({ node, keyword: 'justification', type: TOKEN_STRUCTURE });
+            acceptor({ node, keyword: 'implements', type: TOKEN_STRUCTURE });
+        } else if (isTemplate(node)) {
+            acceptor({ node, keyword: 'template', type: TOKEN_STRUCTURE });
+            acceptor({ node, keyword: 'implements', type: TOKEN_STRUCTURE });
+        } else if (isRelation(node)) {
+            acceptor({ node, keyword: 'supports', type: TOKEN_RELATION });
+        } else if (isAbstractSupport(node)) {
+            acceptor({ node, keyword: '@support', type: TOKEN_ABSTRACT });
+        } else if (isEvidence(node)) {
+            acceptor({ node, keyword: 'evidence', type: TOKEN_ELEMENT });
+        } else if (isConclusion(node)) {
+            acceptor({ node, keyword: 'conclusion', type: TOKEN_ELEMENT });
+        } else if (isStrategy(node)) {
+            acceptor({ node, keyword: 'strategy', type: TOKEN_ELEMENT });
+        } else if (isSubConclusion(node)) {
+            acceptor({ node, keyword: 'sub-conclusion', type: TOKEN_ELEMENT });
+        }
+    }
+}

--- a/packages/language/test/hovering.test.ts
+++ b/packages/language/test/hovering.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, test } from 'vitest';
+import { EmptyFileSystem } from 'langium';
+import { expectHover } from 'langium/test';
+import { createJpipeServices } from 'jpipe-language';
+
+let hover: ReturnType<typeof expectHover>;
+
+beforeAll(async () => {
+    const services = createJpipeServices(EmptyFileSystem);
+    hover = expectHover(services.Jpipe);
+});
+
+describe('hover provider', () => {
+
+    test('shows label for evidence', async () => {
+        await hover({
+            text: 'justification J { evidence e<|>1 is "My Evidence" conclusion c1 is "x" e1 supports c1 }',
+            index: 0,
+            hover: '**My Evidence** *(evidence)*',
+            disposeAfterCheck: true
+        });
+    });
+
+    test('shows label for strategy', async () => {
+        await hover({
+            text: 'justification J { evidence e1 is "x" strategy s<|>1 is "My Strategy" conclusion c1 is "x" e1 supports s1 s1 supports c1 }',
+            index: 0,
+            hover: '**My Strategy** *(strategy)*',
+            disposeAfterCheck: true
+        });
+    });
+
+    test('shows label for conclusion', async () => {
+        await hover({
+            text: 'justification J { evidence e1 is "x" conclusion c<|>1 is "My Conclusion" e1 supports c1 }',
+            index: 0,
+            hover: '**My Conclusion** *(conclusion)*',
+            disposeAfterCheck: true
+        });
+    });
+
+    test('shows label for sub-conclusion with correct kind', async () => {
+        await hover({
+            text: 'justification J { evidence e1 is "x" strategy s1 is "x" sub-conclusion sc<|>1 is "My SubConclusion" conclusion c1 is "x" e1 supports s1 s1 supports sc1 sc1 supports c1 }',
+            index: 0,
+            hover: '**My SubConclusion** *(sub-conclusion)*',
+            disposeAfterCheck: true
+        });
+    });
+
+    test('shows label for @support with correct kind', async () => {
+        await hover({
+            text: 'template T { @support abs<|>1 is "Abstract One" }',
+            index: 0,
+            hover: '**Abstract One** *(@support)*',
+            disposeAfterCheck: true
+        });
+    });
+
+    test('shows id for justification', async () => {
+        await hover({
+            text: 'justification <|>J { evidence e1 is "x" conclusion c1 is "x" e1 supports c1 }',
+            index: 0,
+            hover: '**J** *(justification)*',
+            disposeAfterCheck: true
+        });
+    });
+
+    test('shows id for template', async () => {
+        await hover({
+            text: 'template <|>T { @support abs1 is "Abstract Support" }',
+            index: 0,
+            hover: '**T** *(template)*',
+            disposeAfterCheck: true
+        });
+    });
+});


### PR DESCRIPTION
This pull request introduces significant improvements to the jPipe VS Code extension, focusing on enhanced semantic highlighting, a more organized context menu, robust diagram export functionality, and better error handling and logging. Additionally, it adds a hover provider for the language server to display contextual information for AST nodes. Below are the most important changes grouped by theme:

**Semantic Highlighting and Language Features**
- Added new semantic token types and scopes for the `jpipe` language in `package.json`, enabling more granular syntax highlighting for keywords such as imports, structural elements, relations, and diagram elements.
- Introduced a `JpipeHoverProvider` in the language server (`jpipe-hover-provider.ts`) to show informative hover tooltips for key AST nodes like evidence, strategies, conclusions, and templates.

**Context Menu and Command Improvements**
- Refactored the context menu for the `jpipe` editor: commands are now grouped under a new "jPipe" submenu, with export and preview actions organized for better usability. [[1]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fR146-R151) [[2]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fL117-R198)

**Diagram Export and Preview Robustness**
- Improved the export commands to always use the correct document and diagram context, even when exporting from the preview panel. This is achieved by tracking the last rendered document and diagram, and by updating the export command registration logic. [[1]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939R22-R33) [[2]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939R333-R337) [[3]](diffhunk://#diff-a5c7facc38f10575638877ebaefeab0ece79ea204d773afeec5eb9f202554aedR22-R43)
- Enhanced the preview panel UX: the preview editor group is now automatically locked to prevent accidental closing, and the panel uses custom icons. [[1]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939R48-R52) [[2]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939L268-R316)

**Error Handling and Logging Enhancements**
- Updated the image generation and diagnostic commands to log at the `info` level and to reveal the output channel on critical errors, improving visibility of issues for users. [[1]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L118-R119) [[2]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L206-R207) [[3]](diffhunk://#diff-d9aa3fa869bd362df1b0c55ce31d7a6afcd2fafcefbe2848b8deca20f34339f8R34-R35) [[4]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26R232-R243)

**Internal Refactoring**
- Refactored the `ImageGenerator` and `PreviewProvider` classes to allow passing a forced diagram name, ensuring that exports and previews are consistent with the user's selection or last previewed diagram. [[1]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L50-R51) [[2]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L68-R69) [[3]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L217-R220) [[4]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939L106-L119)

These changes collectively improve the extension's usability, reliability, and language tooling support.