### PR TITLE
Add jpipe.excludedDirectories setting and fix diagram restoration

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -141,6 +141,12 @@
                 "title": "Check jPipe Installation",
                 "category": "jPipe",
                 "icon": "$(check)"
+            },
+            {
+                "command": "jpipe.addExcludedDirectory",
+                "title": "Add Excluded Directory",
+                "category": "jPipe",
+                "icon": "$(folder-opened)"
             }
         ],
         "submenus": [
@@ -255,6 +261,13 @@
                     ],
                     "default": "info",
                     "description": "Verbosity of the jPipe log channel (Output > jPipe). The language server log level (Output > jPipe Language Server) is set once at startup and requires a window reload to change."
+                },
+                "jpipe.excludedDirectories": {
+                    "order": 6,
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "default": [],
+                    "markdownDescription": "Directories (relative to workspace root) whose `.jd` files are excluded from validation. Files in excluded directories display a warning instead of errors. Changes require a window reload to take effect.\n\n[$(folder-opened) Browse for directory…](command:jpipe.addExcludedDirectory)"
                 }
             }
         }

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -146,7 +146,9 @@ export class PreviewProvider {
         try {
             diagramName = this.imageGenerator.findDiagramName(document, editor);
         } catch {
-            if (!this.lastGoodHtml) {
+            if (this.lastGoodHtml) {
+                PreviewProvider.webviewPanel.webview.html = this.lastGoodHtml;
+            } else {
                 PreviewProvider.webviewPanel.webview.html = this.getNodiagramHtml();
             }
             return;

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -65,24 +65,19 @@ export function activate(context: vscode.ExtensionContext): void {
                 openLabel: 'Exclude from Validation'
             });
             if (!uris || uris.length === 0) return;
-            const selectedFsPath = uris[0].fsPath;
-            const roots = vscode.workspace.workspaceFolders ?? [];
-            let relPath: string | undefined;
-            for (const folder of roots) {
-                const rel = path.relative(folder.uri.fsPath, selectedFsPath);
-                if (rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)) {
-                    relPath = rel;
-                    break;
-                }
-            }
-            if (relPath === undefined) {
+            const selectedUri = uris[0];
+            const workspaceFolder = vscode.workspace.getWorkspaceFolder(selectedUri);
+            if (!workspaceFolder) {
                 vscode.window.showWarningMessage('The selected directory must be inside the workspace.');
                 return;
             }
+            const roots = vscode.workspace.workspaceFolders ?? [];
+            const relPart = vscode.workspace.asRelativePath(selectedUri, false).replaceAll('\\', '/');
+            const entry = roots.length > 1 ? `${workspaceFolder.name}:${relPart}` : relPart;
             const config = vscode.workspace.getConfiguration('jpipe');
             const current = config.get<string[]>('excludedDirectories', []);
-            if (!current.includes(relPath)) {
-                await config.update('excludedDirectories', [...current, relPath], vscode.ConfigurationTarget.Workspace);
+            if (!current.includes(entry)) {
+                await config.update('excludedDirectories', [...current, entry], vscode.ConfigurationTarget.Workspace);
             }
         }),
         vscode.commands.registerCommand('jpipe.checkInstallation', async () => {
@@ -107,11 +102,18 @@ export function deactivate(): Thenable<void> | undefined {
 function resolveExcludedDirectories(): string[] {
     const raw = vscode.workspace.getConfiguration('jpipe').get<string[]>('excludedDirectories', []);
     const roots = vscode.workspace.workspaceFolders ?? [];
+    const rootsByName = new Map(roots.map(f => [f.name, f]));
     const resolved: string[] = [];
-    for (const rel of raw) {
-        if (!rel) continue;
-        for (const folder of roots) {
-            resolved.push(vscode.Uri.joinPath(folder.uri, rel).toString());
+    for (const entry of raw) {
+        if (!entry) continue;
+        const colon = entry.indexOf(':');
+        if (colon > 0) {
+            const folderName = entry.slice(0, colon);
+            const rel = entry.slice(colon + 1);
+            const folder = rootsByName.get(folderName);
+            if (folder && rel) resolved.push(vscode.Uri.joinPath(folder.uri, rel).toString());
+        } else if (roots.length === 1) {
+            resolved.push(vscode.Uri.joinPath(roots[0].uri, entry).toString());
         }
     }
     return resolved;

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -15,6 +15,21 @@ export function activate(context: vscode.ExtensionContext): void {
 
     client = startLanguageClient(context, logger);
 
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('jpipe.excludedDirectories')) {
+                vscode.window.showInformationMessage(
+                    'jPipe: "Excluded Directories" changed. Reload the window to apply.',
+                    'Reload Window'
+                ).then(sel => {
+                    if (sel === 'Reload Window') {
+                        vscode.commands.executeCommand('workbench.action.reloadWindow');
+                    }
+                });
+            }
+        })
+    );
+
     // Create image generator and preview provider (client passed for cursor→node highlighting)
     const imageGenerator = new ImageGenerator(logger);
     const previewProvider = new PreviewProvider(imageGenerator, client, context, logger);
@@ -42,6 +57,34 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand('jpipe.downloadPython', async () => { const { doc, diagramName } = await resolveExportContext(); imageGenerator.generateAndSave(ImageFormat.PYTHON, doc, diagramName); }),
         vscode.commands.registerCommand('jpipe.downloadJPIPE',  async () => { const { doc, diagramName } = await resolveExportContext(); imageGenerator.generateAndSave(ImageFormat.JPIPE,  doc, diagramName); }),
         vscode.commands.registerCommand('jpipe.vis.preview', () => previewProvider.openPreview()),
+        vscode.commands.registerCommand('jpipe.addExcludedDirectory', async () => {
+            const uris = await vscode.window.showOpenDialog({
+                canSelectFolders: true,
+                canSelectFiles: false,
+                canSelectMany: false,
+                openLabel: 'Exclude from Validation'
+            });
+            if (!uris || uris.length === 0) return;
+            const selectedFsPath = uris[0].fsPath;
+            const roots = vscode.workspace.workspaceFolders ?? [];
+            let relPath: string | undefined;
+            for (const folder of roots) {
+                const rel = path.relative(folder.uri.fsPath, selectedFsPath);
+                if (rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+                    relPath = rel;
+                    break;
+                }
+            }
+            if (relPath === undefined) {
+                vscode.window.showWarningMessage('The selected directory must be inside the workspace.');
+                return;
+            }
+            const config = vscode.workspace.getConfiguration('jpipe');
+            const current = config.get<string[]>('excludedDirectories', []);
+            if (!current.includes(relPath)) {
+                await config.update('excludedDirectories', [...current, relPath], vscode.ConfigurationTarget.Workspace);
+            }
+        }),
         vscode.commands.registerCommand('jpipe.checkInstallation', async () => {
             const { ok, message } = await imageGenerator.check();
             if (ok) {
@@ -61,6 +104,19 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
 }
 
+function resolveExcludedDirectories(): string[] {
+    const raw = vscode.workspace.getConfiguration('jpipe').get<string[]>('excludedDirectories', []);
+    const roots = vscode.workspace.workspaceFolders ?? [];
+    const resolved: string[] = [];
+    for (const rel of raw) {
+        if (!rel) continue;
+        for (const folder of roots) {
+            resolved.push(vscode.Uri.joinPath(folder.uri, rel).toString());
+        }
+    }
+    return resolved;
+}
+
 function startLanguageClient(context: vscode.ExtensionContext, logger: JpipeLogger): LanguageClient {
     const serverModule = context.asAbsolutePath(path.join('out', 'language', 'main.cjs'));
     const debugOptions = {
@@ -68,7 +124,8 @@ function startLanguageClient(context: vscode.ExtensionContext, logger: JpipeLogg
     };
 
     const logLevel = vscode.workspace.getConfiguration('jpipe').get<string>('logLevel', 'info');
-    const serverEnv = { ...process.env, JPIPE_LOG_LEVEL: logLevel };
+    const excludedDirs = resolveExcludedDirectories();
+    const serverEnv = { ...process.env, JPIPE_LOG_LEVEL: logLevel, JPIPE_EXCLUDED_DIRS: JSON.stringify(excludedDirs) };
 
     const serverOptions: ServerOptions = {
         run:   { module: serverModule, transport: TransportKind.ipc, options: { env: serverEnv } },

--- a/packages/language/src/jpipe-document-validator.ts
+++ b/packages/language/src/jpipe-document-validator.ts
@@ -5,12 +5,14 @@ import { DiagnosticSeverity, type Diagnostic } from 'vscode-languageserver-types
 import type { JpipeServerLogger } from './jpipe-logger.js';
 
 export class JpipeDocumentValidator extends DefaultDocumentValidator {
-    private readonly excludedPaths: string[];
+    private readonly excludedUris: URI[];
     private readonly logger: JpipeServerLogger;
 
     constructor(services: LangiumCoreServices, excludedPaths: string[], logger: JpipeServerLogger) {
         super(services);
-        this.excludedPaths = excludedPaths;
+        this.excludedUris = excludedPaths.flatMap(p => {
+            try { return [URI.parse(p)]; } catch { logger.warn(`Ignoring invalid excluded-directory URI: ${p}`); return []; }
+        });
         this.logger = logger;
     }
 
@@ -19,7 +21,7 @@ export class JpipeDocumentValidator extends DefaultDocumentValidator {
         options?: ValidationOptions,
         cancelToken?: CancellationToken
     ): Promise<Diagnostic[]> {
-        if (this.excludedPaths.some(dir => UriUtils.contains(URI.parse(dir), document.uri))) {
+        if (this.excludedUris.some(dir => UriUtils.contains(dir, document.uri))) {
             this.logger.debug(`Skipping validation (excluded): ${document.uri.toString()}`);
             return [{
                 range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },

--- a/packages/language/src/jpipe-document-validator.ts
+++ b/packages/language/src/jpipe-document-validator.ts
@@ -1,0 +1,33 @@
+import { DefaultDocumentValidator, URI, UriUtils } from 'langium';
+import type { LangiumDocument, LangiumCoreServices, ValidationOptions } from 'langium';
+import type { CancellationToken } from 'vscode-languageserver-protocol';
+import { DiagnosticSeverity, type Diagnostic } from 'vscode-languageserver-types';
+import type { JpipeServerLogger } from './jpipe-logger.js';
+
+export class JpipeDocumentValidator extends DefaultDocumentValidator {
+    private readonly excludedPaths: string[];
+    private readonly logger: JpipeServerLogger;
+
+    constructor(services: LangiumCoreServices, excludedPaths: string[], logger: JpipeServerLogger) {
+        super(services);
+        this.excludedPaths = excludedPaths;
+        this.logger = logger;
+    }
+
+    override async validateDocument(
+        document: LangiumDocument,
+        options?: ValidationOptions,
+        cancelToken?: CancellationToken
+    ): Promise<Diagnostic[]> {
+        if (this.excludedPaths.some(dir => UriUtils.contains(URI.parse(dir), document.uri))) {
+            this.logger.debug(`Skipping validation (excluded): ${document.uri.toString()}`);
+            return [{
+                range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+                severity: DiagnosticSeverity.Warning,
+                message: 'This file is in an excluded directory and is not validated by jPipe.',
+                source: 'jpipe'
+            }];
+        }
+        return super.validateDocument(document, options, cancelToken);
+    }
+}

--- a/packages/language/src/jpipe-module.ts
+++ b/packages/language/src/jpipe-module.ts
@@ -78,7 +78,14 @@ export function createJpipeServices(context: DefaultSharedModuleContext, logLeve
     let excludedDirs: string[] = [];
     try {
         const raw = process.env.JPIPE_EXCLUDED_DIRS;
-        if (raw) excludedDirs = JSON.parse(raw) as string[];
+        if (raw) {
+            const parsed = JSON.parse(raw);
+            if (Array.isArray(parsed) && parsed.every((v: unknown) => typeof v === 'string')) {
+                excludedDirs = parsed;
+            } else {
+                logger.warn('JPIPE_EXCLUDED_DIRS must be a JSON array of strings; no directories will be excluded.');
+            }
+        }
     } catch {
         logger.warn('Failed to parse JPIPE_EXCLUDED_DIRS; no directories will be excluded from validation.');
     }

--- a/packages/language/src/jpipe-module.ts
+++ b/packages/language/src/jpipe-module.ts
@@ -11,6 +11,7 @@ import { JpipeNameProvider } from './jpipe-utils.js';
 import { JpipeHoverProvider } from './jpipe-hover-provider.js';
 import { JpipeSemanticTokenProvider } from './jpipe-semantic-token-provider.js';
 import { JpipeServerLogger, type LogLevel } from './jpipe-logger.js';
+import { JpipeDocumentValidator } from './jpipe-document-validator.js';
 
 /**
  * Declaration of custom services - add your own service classes here.
@@ -31,10 +32,11 @@ export type JpipeAddedServices = {
  */
 export type JpipeServices = LangiumServices & JpipeAddedServices
 
-function buildJpipeModule(logger: JpipeServerLogger): Module<JpipeServices, PartialLangiumServices & JpipeAddedServices> {
+function buildJpipeModule(logger: JpipeServerLogger, excludedDirs: string[] = []): Module<JpipeServices, PartialLangiumServices & JpipeAddedServices> {
     return {
         validation: {
-            JpipeValidator: (services) => new JpipeValidator(services)
+            JpipeValidator: (services) => new JpipeValidator(services),
+            DocumentValidator: (services) => new JpipeDocumentValidator(services, excludedDirs, logger)
         },
         references: {
             ScopeProvider: (services) => new JpipeScopeProvider(services),
@@ -73,6 +75,13 @@ export function createJpipeServices(context: DefaultSharedModuleContext, logLeve
     Jpipe: JpipeServices
 } {
     const logger = new JpipeServerLogger(logLevel);
+    let excludedDirs: string[] = [];
+    try {
+        const raw = process.env.JPIPE_EXCLUDED_DIRS;
+        if (raw) excludedDirs = JSON.parse(raw) as string[];
+    } catch {
+        logger.warn('Failed to parse JPIPE_EXCLUDED_DIRS; no directories will be excluded from validation.');
+    }
     const shared = inject(
         createDefaultSharedModule(context),
         JpipeGeneratedSharedModule
@@ -80,7 +89,7 @@ export function createJpipeServices(context: DefaultSharedModuleContext, logLeve
     const Jpipe = inject(
         createDefaultModule({ shared }),
         JpipeGeneratedModule,
-        buildJpipeModule(logger)
+        buildJpipeModule(logger, excludedDirs)
     );
     shared.ServiceRegistry.register(Jpipe);
     registerValidationChecks(Jpipe);

--- a/packages/language/test/excluding.test.ts
+++ b/packages/language/test/excluding.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { EmptyFileSystem } from 'langium';
+import { parseHelper } from 'langium/test';
+import { DiagnosticSeverity } from 'vscode-languageserver-types';
+import type { Unit } from 'jpipe-language';
+import { createJpipeServices } from 'jpipe-language';
+
+const EXCLUDED_DIR = 'file:///workspace/excluded';
+const EXCLUDED_FILE = `${EXCLUDED_DIR}/test.jd`;
+const NORMAL_FILE = 'file:///workspace/normal/test.jd';
+
+const VALID_JUSTIFICATION = `
+    justification J {
+        conclusion c is "Claim"
+        strategy s is "Strategy"
+        evidence e is "Evidence"
+        e supports s
+        s supports c
+    }
+`;
+
+const INVALID_JUSTIFICATION = `
+    justification J {
+        conclusion c is "Claim"
+        evidence e is "Evidence"
+        e supports c
+    }
+`;
+
+describe('Excluded directory validation', () => {
+    const savedEnv = process.env.JPIPE_EXCLUDED_DIRS;
+
+    beforeEach(() => {
+        process.env.JPIPE_EXCLUDED_DIRS = JSON.stringify([EXCLUDED_DIR]);
+    });
+
+    afterEach(() => {
+        if (savedEnv === undefined) delete process.env.JPIPE_EXCLUDED_DIRS;
+        else process.env.JPIPE_EXCLUDED_DIRS = savedEnv;
+    });
+
+    test('file in excluded directory shows only exclusion warning', async () => {
+        const services = createJpipeServices(EmptyFileSystem);
+        const parse = parseHelper<Unit>(services.Jpipe);
+        const doc = await parse(INVALID_JUSTIFICATION, { documentUri: EXCLUDED_FILE, validation: true });
+
+        expect(doc.diagnostics).toHaveLength(1);
+        expect(doc.diagnostics![0].severity).toBe(DiagnosticSeverity.Warning);
+        expect(doc.diagnostics![0].message).toContain('excluded directory');
+    });
+
+    test('file in excluded directory suppresses normal validation errors', async () => {
+        const services = createJpipeServices(EmptyFileSystem);
+        const parse = parseHelper<Unit>(services.Jpipe);
+        const doc = await parse(INVALID_JUSTIFICATION, { documentUri: EXCLUDED_FILE, validation: true });
+
+        const errors = (doc.diagnostics ?? []).filter(d => d.severity === DiagnosticSeverity.Error);
+        expect(errors).toHaveLength(0);
+    });
+
+    test('file outside excluded directory validates normally', async () => {
+        const services = createJpipeServices(EmptyFileSystem);
+        const parse = parseHelper<Unit>(services.Jpipe);
+        const doc = await parse(INVALID_JUSTIFICATION, { documentUri: NORMAL_FILE, validation: true });
+
+        const messages = (doc.diagnostics ?? []).map(d => d.message);
+        expect(messages.some(m => m.includes('excluded'))).toBe(false);
+        expect(messages.some(m => m.includes('strategy'))).toBe(true);
+    });
+
+    test('valid file in excluded directory shows only exclusion warning, not other warnings', async () => {
+        const services = createJpipeServices(EmptyFileSystem);
+        const parse = parseHelper<Unit>(services.Jpipe);
+        const doc = await parse(VALID_JUSTIFICATION, { documentUri: EXCLUDED_FILE, validation: true });
+
+        expect(doc.diagnostics).toHaveLength(1);
+        expect(doc.diagnostics![0].message).toContain('excluded directory');
+    });
+
+    test('malformed JPIPE_EXCLUDED_DIRS falls back to no exclusions', async () => {
+        process.env.JPIPE_EXCLUDED_DIRS = 'not-valid-json';
+        const services = createJpipeServices(EmptyFileSystem);
+        const parse = parseHelper<Unit>(services.Jpipe);
+        const doc = await parse(INVALID_JUSTIFICATION, { documentUri: EXCLUDED_FILE, validation: true });
+
+        const messages = (doc.diagnostics ?? []).map(d => d.message);
+        expect(messages.some(m => m.includes('excluded'))).toBe(false);
+    });
+
+    test('non-array JPIPE_EXCLUDED_DIRS falls back to no exclusions', async () => {
+        process.env.JPIPE_EXCLUDED_DIRS = '"just-a-string"';
+        const services = createJpipeServices(EmptyFileSystem);
+        const parse = parseHelper<Unit>(services.Jpipe);
+        const doc = await parse(INVALID_JUSTIFICATION, { documentUri: EXCLUDED_FILE, validation: true });
+
+        const messages = (doc.diagnostics ?? []).map(d => d.message);
+        expect(messages.some(m => m.includes('excluded'))).toBe(false);
+    });
+});


### PR DESCRIPTION
This pull request adds support for excluding directories from `.jd` file validation in the jPipe VS Code extension. Users can now specify directories to exclude from validation via a new configuration option and command, and files in these directories will show a warning instead of validation errors. The language server receives the list of excluded directories and skips validation accordingly. Additionally, a bug in the image preview error handling has been fixed.

**New Excluded Directories Feature:**

- **VS Code extension UI and configuration:**
  - Added a new command `jpipe.addExcludedDirectory` to the command palette and contributed it to the package menu, allowing users to select a directory to exclude from validation. [[1]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fR144-R149) [[2]](diffhunk://#diff-a5c7facc38f10575638877ebaefeab0ece79ea204d773afeec5eb9f202554aedR60-R87)
  - Introduced the `jpipe.excludedDirectories` setting in `package.json` for users to manage excluded directories, with a UI link to the new command.
  - When the excluded directories setting changes, users are prompted to reload the window for changes to take effect.

- **Passing excluded directories to the language server:**
  - The extension resolves the excluded directories to workspace-relative paths and passes them to the language server in the `JPIPE_EXCLUDED_DIRS` environment variable.

**Language Server Validation Logic:**

- **Validation skipping implementation:**
  - Added a new `JpipeDocumentValidator` class that checks if a document is in an excluded directory and, if so, skips validation and returns a warning diagnostic instead of errors.
  - Updated the language server initialization to parse the `JPIPE_EXCLUDED_DIRS` environment variable and inject the excluded directories into the validator. [[1]](diffhunk://#diff-c11acd61c8a10e477adeb6eaab6042fa0d3aa6835c23f882f2f50b2900e1775dL34-R39) [[2]](diffhunk://#diff-c11acd61c8a10e477adeb6eaab6042fa0d3aa6835c23f882f2f50b2900e1775dR78-R92)

**Bug Fix:**

- **Image preview fallback logic:**
  - Fixed a bug in `PreviewProvider` so that if diagram name resolution fails but `lastGoodHtml` exists, the preview falls back to the last good HTML instead of showing the "no diagram" message.