### PR TITLE
Redesign outline with namespace grouping and fix inherited element labels

### DIFF
--- a/packages/language/src/jpipe-import.ts
+++ b/packages/language/src/jpipe-import.ts
@@ -255,17 +255,19 @@ export class JpipeImportService {
         owner: Justification | Template,
         unit: Unit,
         currentDoc: LangiumDocument
-    ): Array<{ element: JustificationElement; key: string }> {
-        const result: Array<{ element: JustificationElement; key: string }> = [];
+    ): Array<{ element: JustificationElement; key: string; localKey: string }> {
+        const result: Array<{ element: JustificationElement; key: string; localKey: string }> = [];
         const visited = new Set<Template>();
         let parent = owner.parent?.ref;
         while (parent && !visited.has(parent)) {
             visited.add(parent);
             const ns = this.getNamespaceForTemplate(parent, unit, currentDoc);
-            // Include template name in the prefix: ns:templateId: or templateId:
+            // key includes namespace for scope resolution; localKey omits it for display.
             const prefix = ns ? `${ns}:${parent.id}:` : `${parent.id}:`;
+            const localPrefix = `${parent.id}:`;
             for (const el of (parent.contents?.body ?? []) as JustificationElement[]) {
-                result.push({ element: el, key: prefix + qualifiedIdText(el.id) });
+                const elId = qualifiedIdText(el.id);
+                result.push({ element: el, key: prefix + elId, localKey: localPrefix + elId });
             }
             parent = parent.parent?.ref;
         }

--- a/packages/language/src/jpipe-symbol-provider.ts
+++ b/packages/language/src/jpipe-symbol-provider.ts
@@ -146,11 +146,17 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
         });
 
         // Inherited elements from parent templates (transitively).
+        // Label: "templateId:elementQualifiedId" — omits namespace, keeps template context.
         const { document: doc, unit } = this.getDocumentAndUnit(owner);
         const inherited = doc && unit
-            ? this.importService.getInheritedElementsWithKeys(owner, unit, doc).map(({ element }) =>
-                syntheticSymbol(`(inherited) ${qualifiedIdText(element.id)}`, elementKind(element), ownerRange)
-            )
+            ? this.importService.getInheritedElementsWithKeys(owner, unit, doc).map(({ element }) => {
+                const parentTemplate = element.$container?.$container;
+                const templateId = parentTemplate && isTemplate(parentTemplate) ? parentTemplate.id : undefined;
+                const qualName = templateId
+                    ? `${templateId}:${qualifiedIdText(element.id)}`
+                    : qualifiedIdText(element.id);
+                return syntheticSymbol(`(inherited) ${qualName}`, elementKind(element), ownerRange);
+            })
             : [];
 
         const children = [...local, ...inherited];

--- a/packages/language/src/jpipe-symbol-provider.ts
+++ b/packages/language/src/jpipe-symbol-provider.ts
@@ -63,14 +63,19 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
         }
 
         for (const load of unnamedLoads) {
-            defaultChildren.push(...this.buildUnnamedLoadModels(load, document));
+            const importedUnit = this.resolveImportedUnit(load, document);
+            if (importedUnit) {
+                const loadRange = load.$cstNode?.range ?? ZERO_RANGE;
+                defaultChildren.push(...this.buildImportedModelSymbols(importedUnit, loadRange));
+            }
         }
 
         const symbols: DocumentSymbol[] = [];
 
         if (defaultChildren.length > 0) {
+            const unitRange = unit.$cstNode?.range ?? ZERO_RANGE;
             symbols.push({
-                ...syntheticSymbol('(default)', SymbolKind.Module, ZERO_RANGE),
+                ...syntheticSymbol('(default)', SymbolKind.Module, unitRange),
                 children: defaultChildren,
             });
         }
@@ -83,14 +88,13 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
         return symbols;
     }
 
-    private buildUnnamedLoadModels(load: Load, document: LangiumDocument): DocumentSymbol[] {
+    private resolveImportedUnit(load: Load, document: LangiumDocument): Unit | undefined {
         const importedDoc = this.importService.parseDocumentFromPath(load.path, document);
-        const importedUnit = importedDoc?.parseResult?.value as Unit | undefined;
-        if (!importedUnit) return [];
+        return importedDoc?.parseResult?.value as Unit | undefined;
+    }
 
-        const loadRange = load.$cstNode?.range ?? ZERO_RANGE;
+    private buildImportedModelSymbols(importedUnit: Unit, loadRange: Range): DocumentSymbol[] {
         const results: DocumentSymbol[] = [];
-
         for (const body of importedUnit.body) {
             if (!isJustification(body) && !isTemplate(body)) continue;
             const kind = isJustification(body) ? SymbolKind.Class : SymbolKind.Interface;
@@ -111,23 +115,10 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
         loadRange: Range,
         document: LangiumDocument
     ): DocumentSymbol {
-        const importedDoc = this.importService.parseDocumentFromPath(load.path, document);
-        const importedUnit = importedDoc?.parseResult?.value as Unit | undefined;
-        const children: DocumentSymbol[] = [];
-
-        if (importedUnit) {
-            for (const body of importedUnit.body) {
-                if (!isJustification(body) && !isTemplate(body)) continue;
-                const kind = isJustification(body) ? SymbolKind.Class : SymbolKind.Interface;
-                const elementChildren = getLocalElements(body).map(e =>
-                    syntheticSymbol(qualifiedIdText(e.id), elementKind(e), loadRange)
-                );
-                children.push({
-                    ...syntheticSymbol(body.id, kind, loadRange),
-                    children: elementChildren.length > 0 ? elementChildren : undefined
-                });
-            }
-        }
+        const importedUnit = this.resolveImportedUnit(load, document);
+        const children = importedUnit
+            ? this.buildImportedModelSymbols(importedUnit, loadRange)
+            : [];
 
         return {
             ...syntheticSymbol(ns, SymbolKind.Module, loadRange),
@@ -146,17 +137,12 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
         });
 
         // Inherited elements from parent templates (transitively).
-        // Label: "templateId:elementQualifiedId" — omits namespace, keeps template context.
+        // localKey = templateId:elementQualifiedId, omitting any namespace prefix.
         const { document: doc, unit } = this.getDocumentAndUnit(owner);
         const inherited = doc && unit
-            ? this.importService.getInheritedElementsWithKeys(owner, unit, doc).map(({ element }) => {
-                const parentTemplate = element.$container?.$container;
-                const templateId = parentTemplate && isTemplate(parentTemplate) ? parentTemplate.id : undefined;
-                const qualName = templateId
-                    ? `${templateId}:${qualifiedIdText(element.id)}`
-                    : qualifiedIdText(element.id);
-                return syntheticSymbol(`(inherited) ${qualName}`, elementKind(element), ownerRange);
-            })
+            ? this.importService.getInheritedElementsWithKeys(owner, unit, doc).map(({ element, localKey }) =>
+                syntheticSymbol(`(inherited) ${localKey}`, elementKind(element), ownerRange)
+            )
             : [];
 
         const children = [...local, ...inherited];

--- a/packages/language/src/jpipe-symbol-provider.ts
+++ b/packages/language/src/jpipe-symbol-provider.ts
@@ -20,6 +20,8 @@ import {
 } from './generated/ast.js';
 import { getLocalElements, qualifiedIdText } from './jpipe-utils.js';
 
+const ZERO_RANGE: Range = { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } };
+
 function elementKind(e: JustificationElement): SymbolKind {
     if (isConclusion(e))      return SymbolKind.Constructor;
     if (isStrategy(e))        return SymbolKind.Method;
@@ -48,25 +50,59 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
         const unit = document.parseResult?.value as Unit | undefined;
         if (!unit) return [];
 
-        const symbols: DocumentSymbol[] = [];
+        const unnamedLoads = unit.imports.filter(l => !l.namespace);
+        const namedLoads   = unit.imports.filter(l => !!l.namespace);
 
-        // 1. Named load statements → Module group containing imported models.
-        for (const load of unit.imports) {
-            const ns = load.namespace;
-            if (!ns || !load.$cstNode) continue;
-            const loadRange = load.$cstNode.range;
-            symbols.push(this.buildNamespaceSymbol(load, ns, loadRange, document));
-        }
+        // Default namespace: local models first, then models from unnamed loads.
+        const defaultChildren: DocumentSymbol[] = [];
 
-        // 2. Local Justifications and Templates.
         for (const body of unit.body) {
             if (!isJustification(body) && !isTemplate(body)) continue;
             if (!body.$cstNode) continue;
-            const sym = this.buildModelSymbol(body, document);
-            symbols.push(sym);
+            defaultChildren.push(this.buildModelSymbol(body));
+        }
+
+        for (const load of unnamedLoads) {
+            defaultChildren.push(...this.buildUnnamedLoadModels(load, document));
+        }
+
+        const symbols: DocumentSymbol[] = [];
+
+        if (defaultChildren.length > 0) {
+            symbols.push({
+                ...syntheticSymbol('(default)', SymbolKind.Module, ZERO_RANGE),
+                children: defaultChildren,
+            });
+        }
+
+        for (const load of namedLoads) {
+            if (!load.$cstNode || !load.namespace) continue;
+            symbols.push(this.buildNamespaceSymbol(load, load.namespace, load.$cstNode.range, document));
         }
 
         return symbols;
+    }
+
+    private buildUnnamedLoadModels(load: Load, document: LangiumDocument): DocumentSymbol[] {
+        const importedDoc = this.importService.parseDocumentFromPath(load.path, document);
+        const importedUnit = importedDoc?.parseResult?.value as Unit | undefined;
+        if (!importedUnit) return [];
+
+        const loadRange = load.$cstNode?.range ?? ZERO_RANGE;
+        const results: DocumentSymbol[] = [];
+
+        for (const body of importedUnit.body) {
+            if (!isJustification(body) && !isTemplate(body)) continue;
+            const kind = isJustification(body) ? SymbolKind.Class : SymbolKind.Interface;
+            const elementChildren = getLocalElements(body).map(e =>
+                syntheticSymbol(qualifiedIdText(e.id), elementKind(e), loadRange)
+            );
+            results.push({
+                ...syntheticSymbol(body.id, kind, loadRange),
+                children: elementChildren.length > 0 ? elementChildren : undefined,
+            });
+        }
+        return results;
     }
 
     private buildNamespaceSymbol(
@@ -83,12 +119,11 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
             for (const body of importedUnit.body) {
                 if (!isJustification(body) && !isTemplate(body)) continue;
                 const kind = isJustification(body) ? SymbolKind.Class : SymbolKind.Interface;
-                const name = `${ns}:${body.id}`;
                 const elementChildren = getLocalElements(body).map(e =>
-                    syntheticSymbol(`${ns}:${qualifiedIdText(e.id)}`, elementKind(e), loadRange)
+                    syntheticSymbol(qualifiedIdText(e.id), elementKind(e), loadRange)
                 );
                 children.push({
-                    ...syntheticSymbol(name, kind, loadRange),
+                    ...syntheticSymbol(body.id, kind, loadRange),
                     children: elementChildren.length > 0 ? elementChildren : undefined
                 });
             }
@@ -100,13 +135,9 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
         };
     }
 
-    private buildModelSymbol(
-        owner: Justification | Template,
-        document: LangiumDocument
-    ): DocumentSymbol {
+    private buildModelSymbol(owner: Justification | Template): DocumentSymbol {
         const kind = isJustification(owner) ? SymbolKind.Class : SymbolKind.Interface;
         const ownerRange = owner.$cstNode!.range;
-        const nameRange = owner.$cstNode!.range;
 
         // Local elements.
         const local = getLocalElements(owner).map(e => {
@@ -114,13 +145,12 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
             return syntheticSymbol(qualifiedIdText(e.id), elementKind(e), range);
         });
 
-        // Inherited elements from parent templates.
+        // Inherited elements from parent templates (transitively).
         const { document: doc, unit } = this.getDocumentAndUnit(owner);
         const inherited = doc && unit
-            ? this.importService.getInheritedElementsWithKeys(owner, unit, doc).map(({ element, key }) => {
-                const range = ownerRange;
-                return syntheticSymbol(`(inherited) ${key}`, elementKind(element), range);
-            })
+            ? this.importService.getInheritedElementsWithKeys(owner, unit, doc).map(({ element }) =>
+                syntheticSymbol(`(inherited) ${qualifiedIdText(element.id)}`, elementKind(element), ownerRange)
+            )
             : [];
 
         const children = [...local, ...inherited];
@@ -129,7 +159,7 @@ export class JpipeDocumentSymbolProvider extends DefaultDocumentSymbolProvider {
             name: owner.id,
             kind,
             range: ownerRange,
-            selectionRange: nameRange,
+            selectionRange: ownerRange,
             children: children.length > 0 ? children : undefined
         };
     }

--- a/packages/language/test/symbol-provider.test.ts
+++ b/packages/language/test/symbol-provider.test.ts
@@ -1,0 +1,137 @@
+import { beforeAll, describe, expect, test } from 'vitest';
+import { EmptyFileSystem } from 'langium';
+import { parseHelper } from 'langium/test';
+import { SymbolKind, type DocumentSymbol } from 'vscode-languageserver-types';
+import type { Unit } from 'jpipe-language';
+import { createJpipeServices } from 'jpipe-language';
+
+let services: ReturnType<typeof createJpipeServices>;
+let parse: ReturnType<typeof parseHelper<Unit>>;
+
+beforeAll(async () => {
+    services = createJpipeServices(EmptyFileSystem);
+    parse = parseHelper<Unit>(services.Jpipe);
+});
+
+async function getSymbols(input: string): Promise<DocumentSymbol[]> {
+    const doc = await parse(input);
+    return services.Jpipe.lsp.DocumentSymbolProvider!.getSymbols(
+        doc,
+        { textDocument: { uri: doc.uri.toString() } }
+    ) as Promise<DocumentSymbol[]>;
+}
+
+describe('Document symbol provider (outline)', () => {
+
+    test('local justification appears under (default) namespace', async () => {
+        const symbols = await getSymbols(`
+            justification J {
+                conclusion c is "Claim"
+            }
+        `);
+        expect(symbols).toHaveLength(1);
+        expect(symbols[0].name).toBe('(default)');
+        expect(symbols[0].kind).toBe(SymbolKind.Module);
+        expect(symbols[0].children?.map(c => c.name)).toContain('J');
+        expect(symbols[0].children?.find(c => c.name === 'J')?.kind).toBe(SymbolKind.Class);
+    });
+
+    test('local template appears under (default) namespace', async () => {
+        const symbols = await getSymbols(`
+            template T {
+                @support abs is "Abstract"
+            }
+        `);
+        const def = symbols[0];
+        expect(def.name).toBe('(default)');
+        const t = def.children?.find(c => c.name === 'T');
+        expect(t).toBeDefined();
+        expect(t?.kind).toBe(SymbolKind.Interface);
+    });
+
+    test('local elements shown with their qualified name', async () => {
+        const symbols = await getSymbols(`
+            justification J {
+                evidence e is "Evidence"
+                strategy s is "Strategy"
+                conclusion c is "Claim"
+                e supports s
+                s supports c
+            }
+        `);
+        const j = symbols[0].children!.find(c => c.name === 'J')!;
+        const names = j.children!.map(c => c.name);
+        expect(names).toContain('e');
+        expect(names).toContain('s');
+        expect(names).toContain('c');
+    });
+
+    test('inherited elements labeled as (inherited) templateId:elementId', async () => {
+        const symbols = await getSymbols(`
+            template T {
+                @support abs is "Abstract"
+            }
+            justification J implements T {
+                conclusion c is "Claim"
+            }
+        `);
+        const j = symbols[0].children!.find(c => c.name === 'J')!;
+        const names = j.children!.map(c => c.name);
+        expect(names).toContain('c');
+        expect(names).toContain('(inherited) T:abs');
+    });
+
+    test('local elements and inherited elements are both shown under model', async () => {
+        const symbols = await getSymbols(`
+            template Base {
+                @support b:x is "X"
+            }
+            justification J implements Base {
+                evidence e is "Evidence"
+                conclusion c is "Claim"
+                e supports c
+            }
+        `);
+        const j = symbols[0].children!.find(c => c.name === 'J')!;
+        const names = j.children!.map(c => c.name);
+        expect(names).toContain('e');
+        expect(names).toContain('c');
+        expect(names).toContain('(inherited) Base:b:x');
+    });
+
+    test('(default) is omitted when there are no local models', async () => {
+        // A file with only a named load and no local models produces no (default) group.
+        // We can't test real file loads with EmptyFileSystem, so we verify the inverse:
+        // a file with at least one local model always produces a (default) group.
+        const symbols = await getSymbols(`
+            justification J {
+                conclusion c is "Claim"
+            }
+        `);
+        expect(symbols.some(s => s.name === '(default)')).toBe(true);
+    });
+
+    test('element symbol kinds match node types', async () => {
+        const symbols = await getSymbols(`
+            template T {
+                @support abs is "Abs"
+            }
+            justification J implements T {
+                evidence e is "E"
+                strategy s is "S"
+                sub-conclusion sc is "SC"
+                conclusion c is "C"
+                e supports s
+                s supports sc
+                sc supports c
+            }
+        `);
+        const j = symbols[0].children!.find(c => c.name === 'J')!;
+        const byName = Object.fromEntries(j.children!.map(c => [c.name, c.kind]));
+        expect(byName['e']).toBe(SymbolKind.Field);
+        expect(byName['s']).toBe(SymbolKind.Method);
+        expect(byName['sc']).toBe(SymbolKind.Variable);
+        expect(byName['c']).toBe(SymbolKind.Constructor);
+        expect(byName['(inherited) T:abs']).toBe(SymbolKind.TypeParameter);
+    });
+});


### PR DESCRIPTION
This pull request refactors the document symbol provider logic in `jpipe-symbol-provider.ts` to improve the organization and clarity of how symbols are grouped and named in the language server. The changes introduce a clearer separation between named and unnamed imports, group local and unnamed imported models under a default namespace, and enhance the labeling of inherited elements for better context.

Key improvements include:

### Symbol grouping and organization

* Local models and models from unnamed imports are now grouped under a synthetic "(default)" module symbol, providing a clearer structure for documents without explicit namespaces.
* Named imports are handled separately and grouped under their respective namespaces, improving symbol navigation and readability.

### Symbol naming and label clarity

* The labels for inherited elements now include the parent template's ID (e.g., "templateId:elementQualifiedId"), giving more context and making it easier to trace inheritance origins.
* The namespace prefix is removed from child element names in both unnamed and named imports, simplifying and unifying how symbols are displayed.

### Code simplification and robustness

* The `buildModelSymbol` method signature is simplified by removing the unnecessary `document` parameter, as it can be derived internally.
* A constant `ZERO_RANGE` is introduced to handle missing ranges gracefully, preventing potential errors when CST nodes are absent.
* The `selectionRange` for model symbols is now consistently set to the owner's range, ensuring correct highlighting in editors.