### PR TITLE
Route compiler errors to jPipe output channel instead of popups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jpipe-workspace",
     "description": "Base workspace package",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "type": "module",
     "private": true,
     "scripts": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
     "name": "jpipe-extension",
     "displayName": "jPipe Language (McSCert)",
     "description": "Language Support for the jPipe language",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "type": "module",
     "publisher": "mcscert",
     "author": "McMaster Centre for Software Certification (McSCert)",
@@ -285,7 +285,7 @@
         "watch": "npm run build:prepare && concurrently -n tsc,esbuild -c blue,yellow \"tsc -b tsconfig.json --watch\" \"node esbuild.mjs --watch\""
     },
     "dependencies": {
-        "jpipe-language": "1.1.0",
+        "jpipe-language": "1.1.1",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver": "~9.0.1"
     },

--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -223,7 +223,8 @@ export class ImageGenerator {
             if (error?.cancelled === true || String(error?.message ?? '') === 'Save cancelled') {
                 return;
             }
-            vscode.window.showErrorMessage(error.message);
+            this.logger.error(error.message);
+            this.logger.reveal();
         }
     }
     
@@ -232,6 +233,7 @@ export class ImageGenerator {
         const stderr = typeof error?.stderr === 'string' ? error.stderr.trim() : '';
         if (exitCode === 1) {
             this.logger.warn(`Compiler exit 1 (model errors) for '${diagramName}'`);
+            this.logger.reveal();
         } else if (exitCode === 42) {
             this.logger.error(`Compiler exit 42 (crash) for '${diagramName}'`);
             this.logger.reveal();

--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -224,7 +224,7 @@ export class ImageGenerator {
                 return;
             }
             this.logger.error(error.message);
-            this.logger.reveal();
+            this.logger.revealIfLogged('error');
         }
     }
     
@@ -233,13 +233,13 @@ export class ImageGenerator {
         const stderr = typeof error?.stderr === 'string' ? error.stderr.trim() : '';
         if (exitCode === 1) {
             this.logger.warn(`Compiler exit 1 (model errors) for '${diagramName}'`);
-            this.logger.reveal();
+            this.logger.revealIfLogged('warn');
         } else if (exitCode === 42) {
             this.logger.error(`Compiler exit 42 (crash) for '${diagramName}'`);
-            this.logger.reveal();
+            this.logger.revealIfLogged('error');
         } else {
             this.logger.error(`Generation failed for '${diagramName}': ${error instanceof Error ? error.message : String(exitCode ?? error)}`);
-            this.logger.reveal();
+            this.logger.revealIfLogged('error');
         }
         if (stderr) {
             this.logger.warn(`Compiler stderr: ${stderr}`);

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -178,7 +178,7 @@ export class PreviewProvider {
                 ? error.exitCode
                 : (typeof error?.code === 'number' ? error.code : undefined);
             this.logRenderError(document.fileName, exitCode, error);
-            this.logger.reveal();
+            this.logger.revealIfLogged(exitCode === 1 ? 'warn' : 'error');
 
             const svgFromError = this.extractSvgFromOutput(stdout);
             const hasSvg = svgFromError.includes('<svg');

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -174,15 +174,11 @@ export class PreviewProvider {
             this.lastRenderedDiagramName = diagramName;
         } catch (error: any) {
             const stdout = typeof error?.stdout === 'string' ? error.stdout : '';
-            const stderr = typeof error?.stderr === 'string' ? error.stderr : '';
             const exitCode = typeof error?.exitCode === 'number'
                 ? error.exitCode
                 : (typeof error?.code === 'number' ? error.code : undefined);
             this.logRenderError(document.fileName, exitCode, error);
-            const cleanMsg = String(error?.message ?? error)
-                .replace(/.*\[31m/, '')
-                .replace(/\[0m.*/, '')
-                .replace(/.*Command failed.*?SVG\s+/, '');
+            this.logger.reveal();
 
             const svgFromError = this.extractSvgFromOutput(stdout);
             const hasSvg = svgFromError.includes('<svg');
@@ -200,24 +196,9 @@ export class PreviewProvider {
                 );
                 PreviewProvider.webviewPanel.webview.html = html;
                 this.lastGoodHtml = html;
-                const msg = (stderr || cleanMsg).trim();
-                if (exitCode === 1) {
-                    vscode.window.showWarningMessage(msg ? `jPipe: model has errors (exit code 1): ${msg}` : 'jPipe: model has errors (exit code 1)');
-                } else if (exitCode === 42) {
-                    vscode.window.showErrorMessage(msg ? `jPipe: compiler crashed (exit code 42): ${msg}` : 'jPipe: compiler crashed (exit code 42)');
-                } else {
-                    vscode.window.showErrorMessage(msg ? `jPipe Error: ${msg}` : 'jPipe Error: render failed');
-                }
                 this.lastRenderedDocumentUri = document.uri.toString();
                 this.lastRenderedDiagramName = diagramName;
             } else {
-                if (exitCode === 1) {
-                    vscode.window.showWarningMessage(`jPipe: model has errors (exit code 1): ${cleanMsg}`);
-                } else if (exitCode === 42) {
-                    vscode.window.showErrorMessage(`jPipe: compiler crashed (exit code 42): ${cleanMsg}`);
-                } else {
-                    vscode.window.showErrorMessage(`jPipe Error: ${cleanMsg}`);
-                }
                 // Keep the last successfully rendered preview visible; don't replace it with a full-screen error view.
                 if (this.lastGoodHtml) {
                     PreviewProvider.webviewPanel.webview.html = this.lastGoodHtml;

--- a/packages/extension/src/extension/logger.ts
+++ b/packages/extension/src/extension/logger.ts
@@ -33,6 +33,9 @@ export class JpipeLogger {
 
     reveal(): void { this.channel.show(true); }
 
+    /** Reveal the output panel only if `level` would actually be written at the current logLevel. */
+    revealIfLogged(level: LogLevel): void { if (this.shouldLog(level)) this.channel.show(true); }
+
     private write(rank: number, label: string, msg: string): void {
         if (rank > this.rank) return;
         this.channel.appendLine(`${new Date().toISOString()} [${label}] ${msg}`);

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -1,7 +1,7 @@
 {
     "name": "jpipe-language",
     "description": "The language specific package",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "type": "module",
     "engines": {
         "node": ">=20.10.0",


### PR DESCRIPTION
This pull request updates error handling and user notifications in the image generation and preview features of the extension. The main change is to reduce intrusive pop-up error messages in favor of logging errors to the extension's output panel and revealing it to the user when necessary. This should provide a less disruptive user experience while still surfacing important error information.

**Error handling and notification improvements:**

* Replaced calls to `vscode.window.showErrorMessage` and `vscode.window.showWarningMessage` with logging errors and warnings to the extension's logger in `image-generator.ts` and `preview-provider.ts`, and revealing the logger/output panel for visibility. [[1]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L226-R227) [[2]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26R236) [[3]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939L177-R181) [[4]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939L203-L220)
* Removed custom error message cleaning and pop-up notifications in `preview-provider.ts`, relying instead on logging and output panel visibility to communicate errors to the user. [[1]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939L177-R181) [[2]](diffhunk://#diff-dd20ba2cf416bdf644316532356043c0f9378486b6cb12affb11cf0a10dbb939L203-L220)