### PR TITLE
fix: resolve `load` imports via URI.fsPath so they work on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Changelog
 
+### Unreleased
+- Leader: Sébastien Mosser
+  - Bug Fixes:
+    - **Language Server:** Resolve `load` imports via `URI.fsPath` so they work on Windows (drive-letter paths were malformed under `URI.path`, silently breaking imports and cross-references)
+  - Features:
+    - **Language Server:** Surface unresolved `load` paths as diagnostics instead of failing silently
+    - **Language Server:** Go-to-definition on a `load "..."` path navigates to the loaded document
+
+### v1.1.1 (2026-05-08)
+- Leader: Sébastien Mosser
+  - Features:
+    - **Extension:** Route compiler errors to the jPipe output channel instead of notification popups
+    - **Extension:** Gate the output-channel reveal on the configured `jpipe.logLevel` (panel no longer opens with no visible message)
+
 ### v1.1.0 (2026-04-28)
 - Leader: Sébastien Mosser
   - Features:

--- a/packages/language/src/jpipe-completion.ts
+++ b/packages/language/src/jpipe-completion.ts
@@ -1,4 +1,4 @@
-import { stream, type Stream, URI, AstUtils, GrammarAST, type AstNode, type AstNodeDescription, type ReferenceInfo, type LangiumDocument } from 'langium';
+import { stream, type Stream, AstUtils, GrammarAST, type AstNode, type AstNodeDescription, type ReferenceInfo, type LangiumDocument } from 'langium';
 import {
     DefaultCompletionProvider,
     type CompletionAcceptor,
@@ -30,7 +30,7 @@ import {
     type JustificationElement,
     type AbstractSupport
 } from './generated/ast.js';
-import { getLocalElements, qualifiedIdText } from './jpipe-utils.js';
+import { fsPathOf, getLocalElements, qualifiedIdText } from './jpipe-utils.js';
 
 export class JpipeCompletionProvider extends DefaultCompletionProvider {
     private readonly services: JpipeServices;
@@ -228,8 +228,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
     private basenameFromDescription(desc: AstNodeDescription): string | undefined {
         const uri = desc.documentUri;
         if (!uri) return undefined;
-        const s = typeof uri === 'string' ? uri : uri.toString();
-        const p = URI.parse(s).path;
+        const p = fsPathOf(uri);
         return path.basename(p) || undefined;
     }
 
@@ -237,7 +236,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
         const doc = (node as { $document?: LangiumDocument }).$document;
         const uri = doc?.uri;
         if (!uri) return undefined;
-        const p = URI.parse(uri.toString()).path;
+        const p = fsPathOf(uri);
         return path.basename(p) || undefined;
     }
 
@@ -390,7 +389,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
 
         const partial = m[1];
         const pathStartCol = linePfx.search(/["']/) + 1;
-        const docPath = URI.parse(document.uri.toString()).path;
+        const docPath = fsPathOf(document.uri);
         const docDir = path.dirname(docPath);
         const makeTextEdit = (p: string) => ({
             range: { start: { line: pos.line, character: pathStartCol }, end: pos },
@@ -424,7 +423,7 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
                 const targetUri = desc.documentUri?.toString();
                 if (!targetUri || seen.has(targetUri)) continue;
                 seen.add(targetUri);
-                const targetPath = URI.parse(targetUri).path;
+                const targetPath = fsPathOf(targetUri);
                 if (targetPath === docPath || !targetPath.endsWith('.jd')) continue;
                 const rel = path.relative(docDir, targetPath).replaceAll('\\', '/');
                 const insertPath = rel.startsWith('../') ? rel : `./${rel}`;
@@ -621,11 +620,8 @@ export class JpipeCompletionProvider extends DefaultCompletionProvider {
         const currentUnit = currentDoc.parseResult.value as Unit | undefined;
         if (!currentUnit) return undefined;
 
-        const currentUri = typeof currentDoc.uri === 'string' ? currentDoc.uri : currentDoc.uri.toString();
-        const targetUri = typeof documentUri === 'string' ? documentUri : documentUri.toString();
-
-        const currentPath = URI.parse(currentUri).path;
-        const targetPath = URI.parse(targetUri).path;
+        const currentPath = fsPathOf(currentDoc.uri);
+        const targetPath = fsPathOf(documentUri);
 
         if (currentPath === targetPath) return undefined;
 

--- a/packages/language/src/jpipe-definition-provider.ts
+++ b/packages/language/src/jpipe-definition-provider.ts
@@ -10,10 +10,12 @@ import {
     isConclusion,
     isEvidence,
     isJustification,
+    isLoad,
     isStrategy,
     isSubConclusion,
     isTemplate,
     type JustificationElement,
+    type Load,
     type QualifiedId,
     type Template,
     type Unit,
@@ -49,9 +51,32 @@ export class JpipeDefinitionProvider extends DefaultDefinitionProvider {
             ));
         }
 
+        // Cursor on a `load "..."` path → navigate to the loaded file.
+        const loadLink = this.loadTargetLink(sourceCstNode);
+        if (loadLink) return loadLink;
+
         // Fallback: if cursor is on a multi-part element id declaration (e.g. t:abs),
         // navigate to the @support or element in the parent template being overridden.
         return this.overrideTargetLink(sourceCstNode);
+    }
+
+    private loadTargetLink(sourceCstNode: CstNode): LocationLink[] | undefined {
+        // Walk up from the CST node to find a containing `load` statement.
+        let node: AstNode | undefined = sourceCstNode.astNode;
+        while (node && !isLoad(node)) node = node.$container;
+        if (!node || !isLoad(node)) return undefined;
+        const load = node as Load;
+
+        const document = this.getDocument(load);
+        if (!document) return undefined;
+
+        const targetDoc = this.importService.parseDocumentFromPath(load.path, document);
+        if (!targetDoc) return undefined; // unresolved path (also flagged by the validator)
+
+        // Target the start of the loaded file; highlight the load statement as the source.
+        const fileStart = { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } };
+        const sourceRange = load.$cstNode?.range ?? sourceCstNode.range;
+        return [LocationLink.create(targetDoc.textDocument.uri, fileStart, fileStart, sourceRange)];
     }
 
     private overrideTargetLink(sourceCstNode: CstNode): LocationLink[] | undefined {

--- a/packages/language/src/jpipe-import.ts
+++ b/packages/language/src/jpipe-import.ts
@@ -11,7 +11,7 @@ import {
     type JustificationElement,
     type Unit
 } from './generated/ast.js';
-import { getAllElements, qualifiedIdText } from './jpipe-utils.js';
+import { fsPathOf, getAllElements, qualifiedIdText } from './jpipe-utils.js';
 
 /**
  * Import service for handling imports and resolving imported documents, templates, and elements.
@@ -55,8 +55,9 @@ export class JpipeImportService {
         let resolvedPath = filePath;
 
         if (relativeToDoc && !path.isAbsolute(filePath)) {
-            const currentUri = URI.parse(relativeToDoc.uri.toString());
-            const currentDir = path.dirname(currentUri.path);
+            // Use fsPath (native path), not URI.path — see fsPathOf docs. On Windows
+            // URI.path is `/c:/...` which breaks win32 path.resolve/fs.existsSync.
+            const currentDir = path.dirname(fsPathOf(relativeToDoc.uri));
             resolvedPath = path.resolve(currentDir, filePath);
         } else if (!path.isAbsolute(filePath)) {
             resolvedPath = filePath;

--- a/packages/language/src/jpipe-import.ts
+++ b/packages/language/src/jpipe-import.ts
@@ -51,17 +51,36 @@ export class JpipeImportService {
         return this.parseDocumentFromPath(cleanPath, relativeToDoc);
     }
 
-    parseDocumentFromPath(filePath: string, relativeToDoc?: LangiumDocument): LangiumDocument | undefined {
-        let resolvedPath = filePath;
-
+    /**
+     * Resolve a (possibly relative) import path to an absolute OS-native filesystem
+     * path, relative to `relativeToDoc` when the path is not already absolute.
+     */
+    resolveFsPath(filePath: string, relativeToDoc?: LangiumDocument): string {
         if (relativeToDoc && !path.isAbsolute(filePath)) {
             // Use fsPath (native path), not URI.path — see fsPathOf docs. On Windows
             // URI.path is `/c:/...` which breaks win32 path.resolve/fs.existsSync.
             const currentDir = path.dirname(fsPathOf(relativeToDoc.uri));
-            resolvedPath = path.resolve(currentDir, filePath);
-        } else if (!path.isAbsolute(filePath)) {
-            resolvedPath = filePath;
+            return path.resolve(currentDir, filePath);
         }
+        return filePath;
+    }
+
+    /**
+     * Returns the resolved absolute path of an import if the target exists (either as
+     * an already-open document or a file on disk), otherwise undefined. Used by the
+     * validator to flag unresolvable `load` statements without parsing them.
+     */
+    resolveExistingImportPath(filePath: string, relativeToDoc?: LangiumDocument): string | undefined {
+        const resolvedPath = this.resolveFsPath(filePath, relativeToDoc);
+        const resolvedUri = URI.file(resolvedPath);
+        if (this.services.shared.workspace.LangiumDocuments.getDocument(resolvedUri)) {
+            return resolvedPath;
+        }
+        return fs.existsSync(resolvedPath) ? resolvedPath : undefined;
+    }
+
+    parseDocumentFromPath(filePath: string, relativeToDoc?: LangiumDocument): LangiumDocument | undefined {
+        const resolvedPath = this.resolveFsPath(filePath, relativeToDoc);
 
         const resolvedUri = URI.file(resolvedPath);
         const existingDoc = this.services.shared.workspace.LangiumDocuments.getDocument(resolvedUri);

--- a/packages/language/src/jpipe-utils.ts
+++ b/packages/language/src/jpipe-utils.ts
@@ -1,4 +1,4 @@
-import { type AstNode, type CstNode } from 'langium';
+import { type AstNode, type CstNode, URI } from 'langium';
 import { DefaultNameProvider } from 'langium';
 import {
     isAbstractSupport,
@@ -7,6 +7,20 @@ import {
     type JustificationElement,
     type QualifiedId
 } from './generated/ast.js';
+
+/**
+ * Returns the OS-native filesystem path for a document URI.
+ *
+ * Always use this (not `URI.path`) when a URI is going to be handed to Node's
+ * `path`/`fs` APIs. `URI.path` yields the URI path component, which on Windows is
+ * `/c:/Users/foo/model.jd` (leading slash before the drive letter, forward
+ * slashes) — feeding that to win32 `path.*`/`fs.*` produces a broken path.
+ * `URI.fsPath` yields the native `c:\Users\foo\model.jd`. On POSIX the two are
+ * identical, which is why the distinction only matters on Windows.
+ */
+export function fsPathOf(uri: URI | string): string {
+    return (typeof uri === 'string' ? URI.parse(uri) : uri).fsPath;
+}
 
 /**
  * Name provider that returns the element's identifier (id field) rather than its label

--- a/packages/language/src/jpipe-utils.ts
+++ b/packages/language/src/jpipe-utils.ts
@@ -15,8 +15,10 @@ import {
  * `path`/`fs` APIs. `URI.path` yields the URI path component, which on Windows is
  * `/c:/Users/foo/model.jd` (leading slash before the drive letter, forward
  * slashes) — feeding that to win32 `path.*`/`fs.*` produces a broken path.
- * `URI.fsPath` yields the native `c:\Users\foo\model.jd`. On POSIX the two are
- * identical, which is why the distinction only matters on Windows.
+ * `URI.fsPath` yields the native `c:\Users\foo\model.jd`. For POSIX-style file
+ * URIs the two are identical; they diverge for Windows drive-letter URIs
+ * (`file:///c:/…`) — including when parsed on a non-Windows host — which is where
+ * the distinction matters.
  */
 export function fsPathOf(uri: URI | string): string {
     return (typeof uri === 'string' ? URI.parse(uri) : uri).fsPath;

--- a/packages/language/src/jpipe-validator.ts
+++ b/packages/language/src/jpipe-validator.ts
@@ -1,4 +1,4 @@
-import type { ValidationAcceptor, ValidationChecks } from 'langium';
+import { AstUtils, type ValidationAcceptor, type ValidationChecks } from 'langium';
 import type {
     JpipeAstType,
     Unit,
@@ -10,7 +10,8 @@ import type {
     AbstractSupport,
     Template,
     Justification,
-    JustificationElement
+    JustificationElement,
+    Load
 } from './generated/ast.js';
 import {
     isTemplate,
@@ -23,6 +24,7 @@ import {
 } from './generated/ast.js';
 import type { JpipeServices } from './jpipe-module.js';
 import type { JpipeServerLogger } from './jpipe-logger.js';
+import type { JpipeImportService } from './jpipe-import.js';
 import { getAllElements, getLocalElements, qualifiedIdText } from './jpipe-utils.js';
 
 export function registerValidationChecks(services: JpipeServices) {
@@ -30,6 +32,7 @@ export function registerValidationChecks(services: JpipeServices) {
     const validator = services.validation.JpipeValidator;
     const checks: ValidationChecks<JpipeAstType> = {
         Unit:           validator.checkUnitNotEmpty,
+        Load:           validator.checkLoadResolves,
         Composition:    [validator.checkOperatorName, validator.checkConfigKeys],
         Template:       [validator.checkDuplicateTemplateName, validator.checkTemplateHasSupport],
         Justification:  [validator.checkDuplicateJustificationName, validator.checkJustificationOverride],
@@ -44,6 +47,7 @@ export function registerValidationChecks(services: JpipeServices) {
 
 export class JpipeValidator {
     private readonly logger: JpipeServerLogger;
+    private readonly importService: JpipeImportService;
 
     private static readonly KNOWN_OPERATORS = new Set(['assemble', 'refine']);
 
@@ -59,6 +63,22 @@ export class JpipeValidator {
 
     constructor(services: JpipeServices) {
         this.logger = services.logger;
+        this.importService = services.references.JpipeImportService;
+    }
+
+    /**
+     * Flags a `load` statement whose target file cannot be found. Without this the
+     * failure is silent (only a server-log warning), so a typo'd or broken path —
+     * or a path that resolves incorrectly on Windows — looks like it did nothing.
+     */
+    checkLoadResolves(load: Load, accept: ValidationAcceptor): void {
+        const document = AstUtils.getDocument(load);
+        const resolved = this.importService.resolveExistingImportPath(load.path, document);
+        if (!resolved) {
+            accept('error',
+                `Cannot resolve load path '${load.path}': no such file.`,
+                { node: load, property: 'path' });
+        }
     }
 
     checkOperatorName(composition: Composition, accept: ValidationAcceptor): void {

--- a/packages/language/test/import.test.ts
+++ b/packages/language/test/import.test.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url';
 import { afterEach, beforeAll, describe, expect, test } from 'vitest';
 import { EmptyFileSystem, URI, type LangiumDocument } from 'langium';
 import { clearDocuments, parseHelper } from 'langium/test';
+import type { Diagnostic, LocationLink } from 'vscode-languageserver-types';
 import type { Unit } from 'jpipe-language';
 import { createJpipeServices, isUnit, isJustification, isTemplate } from 'jpipe-language';
 import { fsPathOf } from '../src/jpipe-utils.js';
@@ -17,6 +18,10 @@ beforeAll(async () => {
     services = createJpipeServices(EmptyFileSystem);
     parse = parseHelper<Unit>(services.Jpipe);
 });
+
+function diagnosticMessages(doc: LangiumDocument): string[] {
+    return (doc.diagnostics ?? []).map((d: Diagnostic) => d.message);
+}
 
 afterEach(async () => {
     if (document) await clearDocuments(services.shared, [document]);
@@ -113,5 +118,102 @@ describe('fsPathOf (Windows path safety)', () => {
         const norm = (p: string) => p.replaceAll('\\', '/');
         expect(norm(fsPathOf(posixUri))).toBe('/home/foo/model.jd');
         expect(norm(fsPathOf(URI.parse(posixUri)))).toBe('/home/foo/model.jd');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Load-path validation — a `load` pointing at a missing file must surface a
+// diagnostic instead of failing silently (only a server-log warning before).
+// ---------------------------------------------------------------------------
+
+describe('Load path validation', () => {
+
+    const parseWithValidation = (text: string, documentUri: string) =>
+        parseHelper<Unit>(services.Jpipe)(text, { validation: true, documentUri });
+
+    test('unresolvable load path reports an error diagnostic', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jpipe-import-'));
+        try {
+            const rootUri = pathToFileURL(path.join(tmpDir, 'root.jd')).toString();
+            document = await parseWithValidation(`
+                load "./does-not-exist.jd"
+                justification J {
+                    conclusion c is "Claim"
+                    strategy s is "Strategy"
+                    evidence e is "Evidence"
+                    e supports s
+                    s supports c
+                }
+            `, rootUri);
+            expect(diagnosticMessages(document).some(m => m.includes('Cannot resolve load path'))).toBe(true);
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true });
+        }
+    });
+
+    test('resolvable load path produces no load diagnostic', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jpipe-import-'));
+        try {
+            fs.writeFileSync(path.join(tmpDir, 'base.jd'), `
+                template T {
+                    conclusion c is "Claim"
+                    @support abs is "Abstract"
+                    abs supports c
+                }
+            `);
+            const rootUri = pathToFileURL(path.join(tmpDir, 'root.jd')).toString();
+            document = await parseWithValidation(`
+                load "./base.jd"
+                justification J implements T {
+                    conclusion c is "Claim"
+                    evidence abs is "Concrete"
+                    abs supports c
+                }
+            `, rootUri);
+            expect(diagnosticMessages(document).some(m => m.includes('Cannot resolve load path'))).toBe(false);
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true });
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Go-to-definition on a `load` path — the cursor on the path string should
+// navigate to the loaded file.
+// ---------------------------------------------------------------------------
+
+describe('Go-to-definition on load path', () => {
+
+    test('navigates from a load path to the loaded document', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jpipe-import-'));
+        try {
+            const basePath = path.join(tmpDir, 'base.jd');
+            fs.writeFileSync(basePath, `
+                template T {
+                    conclusion c is "Claim"
+                    @support abs is "Abstract"
+                    abs supports c
+                }
+            `);
+            const rootUri = pathToFileURL(path.join(tmpDir, 'root.jd')).toString();
+            const text = `load "./base.jd"\njustification J implements T {\n    conclusion c is "Claim"\n    evidence abs is "Concrete"\n    abs supports c\n}`;
+            document = await parse(text, { documentUri: rootUri });
+
+            // Cursor inside the "./base.jd" string on line 0.
+            const character = text.indexOf('base.jd');
+            const defProvider = services.Jpipe.lsp.DefinitionProvider!;
+            const result = await defProvider.getDefinition(document, {
+                textDocument: { uri: rootUri },
+                position: { line: 0, character }
+            });
+
+            expect(result).toBeDefined();
+            expect(result!.length).toBeGreaterThan(0);
+            const targetUri = (result![0] as LocationLink).targetUri;
+            const norm = (p: string) => fsPathOf(p).replaceAll('\\', '/');
+            expect(norm(targetUri)).toBe(norm(pathToFileURL(basePath).toString()));
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true });
+        }
     });
 });

--- a/packages/language/test/import.test.ts
+++ b/packages/language/test/import.test.ts
@@ -105,10 +105,13 @@ describe('fsPathOf (Windows path safety)', () => {
             .toBe('c:\\proj\\base.jd');
     });
 
-    test('is identity-preserving for POSIX paths and accepts URI objects', () => {
+    test('preserves POSIX-style URI paths (modulo separators) and accepts URI objects', () => {
+        // A drive-letter-free URI has no leading-slash quirk to strip; fsPath keeps
+        // the same segments. Normalize separators so this holds on Windows too
+        // (where fsPath uses backslashes).
         const posixUri = 'file:///home/foo/model.jd';
-        expect(fsPathOf(posixUri)).toBe('/home/foo/model.jd');
-        expect(fsPathOf(posixUri)).toBe(URI.parse(posixUri).path);
-        expect(fsPathOf(URI.parse(posixUri))).toBe('/home/foo/model.jd');
+        const norm = (p: string) => p.replaceAll('\\', '/');
+        expect(norm(fsPathOf(posixUri))).toBe('/home/foo/model.jd');
+        expect(norm(fsPathOf(URI.parse(posixUri)))).toBe('/home/foo/model.jd');
     });
 });

--- a/packages/language/test/import.test.ts
+++ b/packages/language/test/import.test.ts
@@ -1,0 +1,114 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { EmptyFileSystem, URI, type LangiumDocument } from 'langium';
+import { clearDocuments, parseHelper } from 'langium/test';
+import type { Unit } from 'jpipe-language';
+import { createJpipeServices, isUnit, isJustification, isTemplate } from 'jpipe-language';
+import { fsPathOf } from '../src/jpipe-utils.js';
+
+let services: ReturnType<typeof createJpipeServices>;
+let parse: ReturnType<typeof parseHelper<Unit>>;
+let document: LangiumDocument<Unit> | undefined;
+
+beforeAll(async () => {
+    services = createJpipeServices(EmptyFileSystem);
+    parse = parseHelper<Unit>(services.Jpipe);
+});
+
+afterEach(async () => {
+    if (document) await clearDocuments(services.shared, [document]);
+    document = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Relative import resolution — exercises the `relativeToDoc` branch of
+// JpipeImportService.parseDocumentFromPath, the exact code path that was
+// malformed on Windows. Runs green on POSIX before and after the fix, so it
+// doubles as a no-regression guard for the whole `load` mechanism.
+// ---------------------------------------------------------------------------
+
+describe('Relative import resolution', () => {
+
+    test('resolves a sibling file loaded with a relative path and links across files', async () => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jpipe-import-'));
+        try {
+            fs.writeFileSync(path.join(tmpDir, 'base.jd'), `
+                template T {
+                    conclusion c is "Claim"
+                    @support abs is "Abstract"
+                    abs supports c
+                }
+            `);
+            const rootPath = path.join(tmpDir, 'root.jd');
+            document = await parse(`
+                load "./base.jd"
+                justification J implements T {
+                    conclusion c is "Claim"
+                    evidence abs is "Concrete"
+                    abs supports c
+                }
+            `, { documentUri: pathToFileURL(rootPath).toString() });
+
+            // Direct test of the relative-resolution branch (the Windows bug site):
+            // resolve "./base.jd" relative to the root document's own URI.
+            const importService = services.Jpipe.references.JpipeImportService;
+            const baseDoc = importService.parseDocumentFromPath('./base.jd', document);
+            expect(baseDoc).toBeDefined();
+            expect(baseDoc!.parseResult.parserErrors).toHaveLength(0);
+            const baseUnit = baseDoc!.parseResult.value as Unit;
+            expect(isUnit(baseUnit)).toBe(true);
+            expect(baseUnit.body.some(b => isTemplate(b) && b.id === 'T')).toBe(true);
+
+            // End-to-end: the cross-file `implements` reference actually links.
+            const j = document.parseResult.value?.body.find(isJustification);
+            expect(j).toBeDefined();
+            expect(j!.parent?.ref?.id).toBe('T');
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true });
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fsPathOf — locks in the URI.path -> URI.fsPath fix. Node's `path` defaults to
+// the host OS, so we assert against path.win32 explicitly to model Windows
+// behaviour on any platform.
+// ---------------------------------------------------------------------------
+
+describe('fsPathOf (Windows path safety)', () => {
+
+    const winUri = 'file:///c:/proj/model.jd';
+
+    test('drops the leading-slash-before-drive that URI.path keeps', () => {
+        // The bug: URI.path yields "/c:/proj/model.jd" (leading slash + drive letter).
+        expect(URI.parse(winUri).path).toBe('/c:/proj/model.jd');
+        // The fix: URI.fsPath yields a native, drive-rooted path (no leading slash).
+        const p = fsPathOf(winUri).replaceAll('\\', '/');
+        expect(/^\/[a-zA-Z]:/.test(p)).toBe(false);
+        expect(p).toBe('c:/proj/model.jd');
+    });
+
+    test('win32 path resolution is broken from URI.path but valid from fsPath', () => {
+        // This is precisely what parseDocumentFromPath does on Windows.
+        const fromPath = URI.parse(winUri).path;            // buggy input
+        const fromFsPath = fsPathOf(winUri).replaceAll('\\', '/'); // fixed input
+
+        // From the buggy value, resolution produces a bogus root-relative path
+        // (leading backslash, no drive), so fs.existsSync fails -> "import not found".
+        expect(path.win32.resolve(path.win32.dirname(fromPath), './base.jd'))
+            .toBe('\\c:\\proj\\base.jd');
+        // From the fixed value, resolution produces a valid drive-rooted path.
+        expect(path.win32.resolve(path.win32.dirname(fromFsPath), './base.jd'))
+            .toBe('c:\\proj\\base.jd');
+    });
+
+    test('is identity-preserving for POSIX paths and accepts URI objects', () => {
+        const posixUri = 'file:///home/foo/model.jd';
+        expect(fsPathOf(posixUri)).toBe('/home/foo/model.jd');
+        expect(fsPathOf(posixUri)).toBe(URI.parse(posixUri).path);
+        expect(fsPathOf(URI.parse(posixUri))).toBe('/home/foo/model.jd');
+    });
+});


### PR DESCRIPTION
## Problem

The `load "..."` instruction imports one `.jd` file into another. It works on macOS/Linux but fails on **Windows**: the loaded file's justifications/templates never resolve and cross-references break.

## Root cause

Import resolution extracted filesystem paths from document URIs using **`URI.path`** (the URI *path component*) instead of **`URI.fsPath`** (the OS-native path):

- `URI.path` for a Windows URI `file:///c:/Users/foo/model.jd` → `/c:/Users/foo/model.jd` — a leading slash before the drive letter, forward slashes.
- `URI.fsPath` → `c:\Users\foo\model.jd`.

Node's `path.*` use **win32** semantics on Windows, so `path.resolve(path.dirname("/c:/Users/foo/model.jd"), "./base.jd")` produces a malformed `\c:\...` path and `fs.existsSync(...)` returns `false` → the import is silently "not found". On POSIX `URI.path` and `URI.fsPath` are identical, which is why it never surfaced on macOS/Linux.

## Fix

- **New `fsPathOf(uri)` helper** in `jpipe-utils.ts`, documenting the trap so it doesn't recur.
- **`parseDocumentFromPath`** in `jpipe-import.ts` (the primary failure site) now derives the base directory from `fsPathOf(relativeToDoc.uri)`.
- **`jpipe-completion.ts`** — the 5 `.path` sites (load-path completion `docDir`, basename helpers, indexed target paths, imported-badge detection) now use `fsPathOf`.

## Tests

Added `packages/language/test/import.test.ts`:

1. **Relative-import regression test** — writes two `.jd` files to a temp dir, resolves `load "./base.jd"` through the previously *untested* relative-resolution branch, and asserts the cross-file `implements` links end-to-end. Green before and after → genuine no-regression guard. (The only prior test hitting `parseDocumentFromPath` used an *absolute* path, skipping the buggy branch, and self-skipped when compiler examples were absent.)
2. **Windows-path unit tests** — assert against `path.win32` explicitly (Node's `path` defaults to the host OS), showing the old `.path` value resolves to the broken `\c:\proj\base.jd` while the `.fsPath` value resolves to the valid `c:\proj\base.jd`. These lock in the fix on any platform.

## Verification

- `npm test` → **80/80 pass** (4 new).
- `tsc -b` → clean.

_Note: not tested on real Windows hardware (unavailable); the `path.win32` assertions model Windows behaviour on POSIX. Drive-letter cache-casing hardening was deliberately left out — the `.fsPath` fix alone restores `load` functionality._

🤖 Generated with [Claude Code](https://claude.com/claude-code)