### PR TITLE
fix: keep diagnostic-view toggle working when the model has errors

### DIFF
--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -8,6 +8,10 @@ import { JpipeLogger } from '../logger.js';
 
 const execAsync = promisify(exec);
 
+/** Max time (ms) to wait for a jPipe CLI/JAR invocation before giving up, so a hung
+ *  compiler surfaces an error instead of freezing the preview panel indefinitely. */
+const CLI_TIMEOUT_MS = 30_000;
+
 /** Expand leading ~ to the user's home directory (Node does not do this by default). */
 function expandTilde(filePath: string): string {
     const home = os.homedir();
@@ -119,7 +123,7 @@ export class ImageGenerator {
         this.logger.info(`Executing: ${command}`);
 
         try {
-            const { stdout } = await execAsync(command);
+            const { stdout } = await execAsync(command, { env: envWithPath(), timeout: CLI_TIMEOUT_MS });
             this.logger.info(`Generated ${format} for '${diagramName}' (${path.basename(document.uri.fsPath)})`);
             return stdout;
         } catch (error: any) {
@@ -165,7 +169,7 @@ export class ImageGenerator {
         }
 
         try {
-            const { stdout, stderr } = await execAsync(command, { env: envWithPath() });
+            const { stdout, stderr } = await execAsync(command, { env: envWithPath(), timeout: CLI_TIMEOUT_MS });
             const output = (stdout + stderr).trim();
             return { ok: true, message: output || 'jPipe is accessible.' };
         } catch (error: any) {
@@ -206,7 +210,7 @@ export class ImageGenerator {
 
         this.logger.info(`Executing: ${command}`);
         try {
-            const { stdout, stderr } = await execAsync(command, { env: envWithPath() });
+            const { stdout, stderr } = await execAsync(command, { env: envWithPath(), timeout: CLI_TIMEOUT_MS });
             return [stdout, stderr].filter(Boolean).join('\n').trim() || '(no output)';
         } catch (e: any) {
             const out = (e.stdout ?? '').trim();

--- a/packages/extension/src/extension/image-generation/preview-provider.ts
+++ b/packages/extension/src/extension/image-generation/preview-provider.ts
@@ -27,6 +27,34 @@ export class PreviewProvider {
         return this.lastRenderedDiagramName;
     }
 
+    /**
+     * Resolve a jPipe document to (re)render, along with the editor that carries the
+     * relevant cursor context. Tries, in order: the active editor, any visible jPipe
+     * editor, and finally the last-rendered document (reopened without an editor).
+     * Returns undefined only when no jPipe document can be found at all.
+     *
+     * This exists so the toolbar toggle keeps working after the user clicks it: clicking
+     * a webview button focuses the webview, which makes `activeTextEditor` undefined.
+     */
+    private async resolveActiveJpipeDocument(): Promise<{ document: vscode.TextDocument; editor: vscode.TextEditor | undefined } | undefined> {
+        const activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor?.document.languageId === 'jpipe') {
+            return { document: activeEditor.document, editor: activeEditor };
+        }
+        const visibleEditor = vscode.window.visibleTextEditors.find(e => e.document.languageId === 'jpipe');
+        if (visibleEditor) {
+            return { document: visibleEditor.document, editor: visibleEditor };
+        }
+        if (this.lastRenderedDocumentUri) {
+            try {
+                const document = await vscode.workspace.openTextDocument(vscode.Uri.parse(this.lastRenderedDocumentUri));
+                const editor = vscode.window.visibleTextEditors.find(e => e.document === document);
+                return { document, editor };
+            } catch { /* fall through */ }
+        }
+        return undefined;
+    }
+
     constructor(
         private readonly imageGenerator: ImageGenerator,
         private readonly languageClient: LanguageClient,
@@ -132,10 +160,18 @@ export class PreviewProvider {
 
         // Diagnostic mode bypasses diagram-name resolution
         if (this.viewMode === 'diagnostic') {
+            // Show a loading indicator while the CLI runs so the panel never looks frozen.
+            PreviewProvider.webviewPanel.webview.html = this.getLoadingHtml();
+            let output: string;
             try {
-                const output = await this.imageGenerator.generateDiagnostic(document);
-                PreviewProvider.webviewPanel.webview.html = this.getHtmlForDiagnostic(output, this.unsaved);
-            } catch { /* ignore diagnostic errors */ }
+                output = await this.imageGenerator.generateDiagnostic(document);
+            } catch (error) {
+                const msg = error instanceof Error ? error.message : String(error);
+                this.logger.error(`Diagnostic failed in ${document.fileName}: ${msg}`);
+                output = `Failed to run diagnostic:\n\n${msg}`;
+            }
+            if (this.viewMode !== 'diagnostic' || !PreviewProvider.webviewPanel) return;
+            PreviewProvider.webviewPanel.webview.html = this.getHtmlForDiagnostic(output, this.unsaved);
             return;
         }
 
@@ -200,13 +236,13 @@ export class PreviewProvider {
                 this.lastRenderedDiagramName = diagramName;
             } else {
                 // Keep the last successfully rendered preview visible; don't replace it with a full-screen error view.
+                // Intentionally retain lastRenderedDocumentUri/lastRenderedDiagramName: they describe what the panel
+                // is still showing (the last good diagram), so the diagnostic toggle always has a document to render.
                 if (this.lastGoodHtml) {
                     PreviewProvider.webviewPanel.webview.html = this.lastGoodHtml;
                 } else {
                     PreviewProvider.webviewPanel.webview.html = this.getLoadingHtml();
                 }
-                this.lastRenderedDocumentUri = undefined;
-                this.lastRenderedDiagramName = undefined;
             }
         }
     }
@@ -335,15 +371,16 @@ export class PreviewProvider {
                 vscode.env.openExternal(vscode.Uri.parse(msg.url));
             }
             if (msg.type === 'toggleMode') {
-                this.viewMode = this.viewMode === 'diagram' ? 'diagnostic' : 'diagram';
-                const activeDoc = vscode.window.activeTextEditor?.document;
-                const docToUse = activeDoc?.languageId === 'jpipe' ? activeDoc : undefined;
-                if (docToUse) {
-                    this.updatePreview(docToUse, vscode.window.activeTextEditor);
-                } else if (this.lastRenderedDocumentUri) {
-                    vscode.workspace.openTextDocument(vscode.Uri.parse(this.lastRenderedDocumentUri))
-                        .then(doc => this.updatePreview(doc, undefined), () => {});
-                }
+                // Resolve a document BEFORE flipping viewMode so we never end up in a
+                // mode we can't render (which leaves the toggle looking frozen).
+                this.resolveActiveJpipeDocument().then(resolved => {
+                    if (!resolved) {
+                        this.logger.warn('Diagnostic toggle ignored: no jPipe document available to render');
+                        return;
+                    }
+                    this.viewMode = this.viewMode === 'diagram' ? 'diagnostic' : 'diagram';
+                    this.updatePreview(resolved.document, resolved.editor);
+                });
             }
         });
         
@@ -584,7 +621,7 @@ export class PreviewProvider {
                 </button>
             </div>
             <div class="toolbar-group">
-                <button class="toolbar-btn" id="mode-toggle" data-tooltip="Diagnostic view"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="6.5" cy="6.5" r="4"/><line x1="10" y1="10" x2="14" y2="14"/></svg></button>
+                <button class="toolbar-btn" id="mode-toggle" data-tooltip="Diagnostic view"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="2.5" width="9" height="12" rx="1.5"/><rect x="5.75" y="1" width="4.5" height="2.6" rx="0.8"/><line x1="6" y1="8.5" x2="10" y2="8.5"/><line x1="6" y1="11.5" x2="10" y2="11.5"/></svg></button>
             </div>
             <div class="toolbar-group">
                 <button class="toolbar-btn zoom" id="zoom-out" title="Zoom out">−</button>
@@ -892,7 +929,7 @@ export class PreviewProvider {
             <a href="#" id="jpipe-link" title="Open jpipe.org">JPIPE</a>
         </div>
         <div>
-            <button class="toolbar-btn active" id="mode-toggle" data-tooltip="Back to diagram view"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="6.5" cy="6.5" r="4"/><line x1="10" y1="10" x2="14" y2="14"/></svg></button>
+            <button class="toolbar-btn active" id="mode-toggle" data-tooltip="Back to diagram view"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="2.5" width="9" height="12" rx="1.5"/><rect x="5.75" y="1" width="4.5" height="2.6" rx="0.8"/><line x1="6" y1="8.5" x2="10" y2="8.5"/><line x1="6" y1="11.5" x2="10" y2="11.5"/></svg></button>
         </div>
     </div>
     <div id="unsaved-banner">⚠ Unsaved changes — diagnostic reflects last saved version</div>


### PR DESCRIPTION
## Problem

The preview toolbar's diagnostic-view toggle would silently do nothing — the panel appeared **frozen** — especially when the jPipe model had errors.

## Root cause

Two facts combined into a state desync:

1. **Clicking a webview button focuses the webview**, so `vscode.window.activeTextEditor` becomes `undefined`.
2. The **no-SVG error render path nulled `lastRenderedDocumentUri`** (while keeping the last-good diagram on screen).

So after a failed render, the toggle handler flipped `viewMode` *before* checking it had a document to render, then found neither `activeTextEditor` nor `lastRenderedDocumentUri` — nothing re-rendered, and `viewMode` was left stuck in the wrong state. The button looked dead.

## Fix

- Resolve the document **before** flipping `viewMode`, via a new `resolveActiveJpipeDocument()` helper (active → visible → last-rendered).
- Stop clearing `lastRenderedDocumentUri`/`lastRenderedDiagramName` on the no-SVG error path — they describe the last-good diagram still on screen.
- Show a loading indicator and surface errors in the diagnostic branch instead of swallowing them in an empty `catch`.
- Add a 30s timeout to CLI invocations so a hung compiler can't freeze the panel indefinitely.
- Swap the magnifying-glass icon (confusable with the adjacent zoom controls) for a clipboard/report icon.

## Testing

Verified manually in the Extension Dev Host: render a valid diagram, introduce an error and save, then click the diagnostic toggle — it now switches to diagnostic output (previously dead) and toggles back cleanly, both when focus is in the editor and in the webview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)