### PR TITLE
Add managed compiler mode and enhance settings configuration

### DIFF
--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -20,6 +20,17 @@
 The plugin requires the `jpipe` compiler to be vailable on your computer:
   - [https://www.jpipe.org/tutorials/install/](https://www.jpipe.org/tutorials/install/)
 
+You can provide the compiler in three ways, selected via the `jpipe.executionMode` setting:
+
+  - **cli** (recommended): the `jpipe` executable on your `PATH` (`jpipe.cliPath`).
+  - **jar**: a JAR you downloaded yourself, run with `java` (`jpipe.jarFile`, `jpipe.javaExecutable`).
+  - **managed** (easiest on Windows): run the **jPipe: Install Compiler from GitHub Release**
+    command and pick a version. The extension downloads the selected compiler JAR over HTTPS
+    from the [jpipe-compiler releases](https://github.com/jpipe-mcscert/jpipe-compiler/releases)
+    into its own private storage and runs it with `java` — no manual path configuration. The
+    downloaded JAR is an executable; the extension only fetches it after you explicitly pick a
+    release, and periodically offers to update it. (Requires a Java runtime.)
+
 #### How to use the plugin?
 
 Simply open a file using the `.jd` extension.

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -159,6 +159,12 @@
                 "icon": "$(cloud-download)"
             },
             {
+                "command": "jpipe.export",
+                "title": "Export Diagram (default format)",
+                "category": "jPipe",
+                "icon": "$(save)"
+            },
+            {
                 "command": "jpipe.addExcludedDirectory",
                 "title": "Add Excluded Directory",
                 "category": "jPipe",
@@ -221,76 +227,174 @@
                 }
             ]
         },
-        "configuration": {
-            "title": "jPipe",
-            "properties": {
-                "jpipe.executionMode": {
-                    "order": 1,
-                    "type": "string",
-                    "enum": [
-                        "cli",
-                        "jar",
-                        "managed"
-                    ],
-                    "enumDescriptions": [
-                        "Use the jpipe CLI executable (recommended). Configure the path below with 'CLI: Path'.",
-                        "Use a JAR file (manual installation / developer mode). Configure the path below with 'JAR: File' and 'JAR: Java Executable'.",
-                        "Use a compiler the extension downloads and manages from GitHub Releases. Install or switch versions via the 'Install Compiler from GitHub Release' command (requires Java)."
-                    ],
-                    "default": "cli",
-                    "markdownDescription": "How to invoke the jPipe compiler. Choose **cli** (recommended), **jar** (manual installation), or **managed** (downloaded automatically from GitHub Releases — easiest on Windows).\n\n[Install from GitHub Release](command:jpipe.installFromRelease) · [Check jPipe installation](command:jpipe.checkInstallation)"
-                },
-                "jpipe.cliPath": {
-                    "order": 2,
-                    "type": "string",
-                    "default": "jpipe",
-                    "markdownDescription": "**[cli mode only]** Path to the `jpipe` CLI executable. Accepts a bare name (resolved via `PATH`), a relative path, or an absolute path."
-                },
-                "jpipe.jarFile": {
-                    "order": 3,
-                    "type": "string",
-                    "default": "",
-                    "markdownDescription": "**[jar mode only]** Absolute path to the `jpipe` JAR file."
-                },
-                "jpipe.javaExecutable": {
-                    "order": 4,
-                    "type": "string",
-                    "default": "java",
-                    "markdownDescription": "**[jar mode only]** Path to the `java` executable used to run the JAR. Defaults to `java` (resolved via `PATH`)."
-                },
-                "jpipe.logLevel": {
-                    "order": 5,
-                    "type": "string",
-                    "enum": [
-                        "off",
-                        "error",
-                        "warn",
-                        "info",
-                        "debug",
-                        "trace"
-                    ],
-                    "enumDescriptions": [
-                        "No logging.",
-                        "Errors only.",
-                        "Errors and warnings.",
-                        "Errors, warnings, and key lifecycle events (default).",
-                        "Detailed operational info (commands, renders, imports).",
-                        "Everything, including per-cursor and per-completion events."
-                    ],
-                    "default": "info",
-                    "description": "Verbosity of the jPipe log channel (Output > jPipe). The language server log level (Output > jPipe Language Server) is set once at startup and requires a window reload to change."
-                },
-                "jpipe.excludedDirectories": {
-                    "order": 6,
-                    "type": "array",
-                    "items": {
-                        "type": "string"
+        "configuration": [
+            {
+                "title": "jPipe: Compiler",
+                "order": 1,
+                "properties": {
+                    "jpipe.executionMode": {
+                        "order": 1,
+                        "type": "string",
+                        "enum": [
+                            "cli",
+                            "jar",
+                            "managed"
+                        ],
+                        "enumDescriptions": [
+                            "Use the jpipe CLI executable (recommended). Configure the path below with 'CLI: Path'.",
+                            "Use a JAR file (manual installation / developer mode). Configure the path below with 'JAR: File' and 'JAR: Java Executable'.",
+                            "Use a compiler the extension downloads and manages from GitHub Releases. Install or switch versions via the 'Install Compiler from GitHub Release' command (requires Java)."
+                        ],
+                        "default": "cli",
+                        "markdownDescription": "How to invoke the jPipe compiler. Choose **cli** (recommended), **jar** (manual installation), or **managed** (downloaded automatically from GitHub Releases — easiest on Windows).\n\n[Install from GitHub Release](command:jpipe.installFromRelease) · [Check jPipe installation](command:jpipe.checkInstallation)"
                     },
-                    "default": [],
-                    "markdownDescription": "Directories (relative to workspace root) whose `.jd` files are excluded from validation. Files in excluded directories display a warning instead of errors. Changes require a window reload to take effect.\n\n[$(folder-opened) Browse for directory…](command:jpipe.addExcludedDirectory)"
+                    "jpipe.cliPath": {
+                        "order": 2,
+                        "type": "string",
+                        "default": "jpipe",
+                        "markdownDescription": "**[cli mode only]** Path to the `jpipe` CLI executable. Accepts a bare name (resolved via `PATH`), a relative path, or an absolute path."
+                    },
+                    "jpipe.jarFile": {
+                        "order": 3,
+                        "type": "string",
+                        "default": "",
+                        "markdownDescription": "**[jar mode only]** Absolute path to the `jpipe` JAR file."
+                    },
+                    "jpipe.javaExecutable": {
+                        "order": 4,
+                        "type": "string",
+                        "default": "java",
+                        "markdownDescription": "**[jar / managed mode]** Path to the `java` executable used to run the JAR. Defaults to `java` (resolved via `PATH`)."
+                    },
+                    "jpipe.compilerTimeout": {
+                        "order": 5,
+                        "type": "number",
+                        "default": 30,
+                        "minimum": 1,
+                        "markdownDescription": "Maximum time, in **seconds**, to wait for a compiler invocation before giving up. Increase for large models on slower machines."
+                    },
+                    "jpipe.jvmArgs": {
+                        "order": 6,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [],
+                        "markdownDescription": "**[jar / managed mode]** Extra arguments passed to `java` before `-jar` (e.g. `[\"-Xmx2g\"]` to raise the heap for large models)."
+                    },
+                    "jpipe.extraPath": {
+                        "order": 7,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [],
+                        "markdownDescription": "Additional directories prepended to `PATH` when running the compiler, so external interpreters (e.g. `python3`, `dot`) can be found. Complements the built-in defaults."
+                    }
+                }
+            },
+            {
+                "title": "jPipe: Managed Compiler",
+                "order": 2,
+                "properties": {
+                    "jpipe.managedCheckForUpdates": {
+                        "order": 1,
+                        "type": "boolean",
+                        "default": true,
+                        "markdownDescription": "When in **managed** mode, periodically check GitHub for a newer compiler release and offer to update."
+                    },
+                    "jpipe.managedUpdateCheckIntervalHours": {
+                        "order": 2,
+                        "type": "number",
+                        "default": 24,
+                        "minimum": 1,
+                        "markdownDescription": "How often, in **hours**, to check for a newer managed compiler release (only when 'Managed: Check For Updates' is enabled)."
+                    },
+                    "jpipe.managedIncludePrereleases": {
+                        "order": 3,
+                        "type": "boolean",
+                        "default": false,
+                        "markdownDescription": "Include pre-release (`-rc`) versions in the 'Install Compiler from GitHub Release' picker. The rolling `unstable` build is never listed."
+                    },
+                    "jpipe.managedRepository": {
+                        "order": 4,
+                        "type": "string",
+                        "default": "jpipe-mcscert/jpipe-compiler",
+                        "markdownDescription": "**[advanced]** GitHub `owner/repo` the managed compiler is downloaded from. Change only to use a fork or a testing repository."
+                    }
+                }
+            },
+            {
+                "title": "jPipe: Export",
+                "order": 3,
+                "properties": {
+                    "jpipe.defaultExportFormat": {
+                        "order": 1,
+                        "type": "string",
+                        "enum": [
+                            "SVG",
+                            "PNG",
+                            "JPEG",
+                            "JSON",
+                            "DOT",
+                            "PYTHON",
+                            "JPIPE"
+                        ],
+                        "default": "SVG",
+                        "markdownDescription": "Format used by the **jPipe: Export Diagram (default format)** command."
+                    },
+                    "jpipe.openAfterExport": {
+                        "order": 2,
+                        "type": "boolean",
+                        "default": false,
+                        "markdownDescription": "Open the exported file automatically after a successful export/download."
+                    }
+                }
+            },
+            {
+                "title": "jPipe: Validation",
+                "order": 4,
+                "properties": {
+                    "jpipe.excludedDirectories": {
+                        "order": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [],
+                        "markdownDescription": "Directories (relative to workspace root) whose `.jd` files are excluded from validation. Files in excluded directories display a warning instead of errors. Changes require a window reload to take effect.\n\n[$(folder-opened) Browse for directory…](command:jpipe.addExcludedDirectory)"
+                    }
+                }
+            },
+            {
+                "title": "jPipe: Logging",
+                "order": 5,
+                "properties": {
+                    "jpipe.logLevel": {
+                        "order": 1,
+                        "type": "string",
+                        "enum": [
+                            "off",
+                            "error",
+                            "warn",
+                            "info",
+                            "debug",
+                            "trace"
+                        ],
+                        "enumDescriptions": [
+                            "No logging.",
+                            "Errors only.",
+                            "Errors and warnings.",
+                            "Errors, warnings, and key lifecycle events (default).",
+                            "Detailed operational info (commands, renders, imports).",
+                            "Everything, including per-cursor and per-completion events."
+                        ],
+                        "default": "info",
+                        "description": "Verbosity of the jPipe log channel (Output > jPipe). The language server log level (Output > jPipe Language Server) is set once at startup and requires a window reload to change."
+                    }
                 }
             }
-        }
+        ]
     },
     "activationEvents": [
         "onLanguage:jpipe"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -362,7 +362,7 @@
                             "type": "string"
                         },
                         "default": [],
-                        "markdownDescription": "Directories (relative to workspace root) whose `.jd` files are excluded from validation. Files in excluded directories display a warning instead of errors. Changes require a window reload to take effect.\n\n[$(folder-opened) Browse for directory…](command:jpipe.addExcludedDirectory)"
+                        "markdownDescription": "Directories (relative to workspace root) whose `.jd` files are excluded from validation. Files in excluded directories display a warning instead of errors. Changes require a window reload to take effect.\n\n[Browse for directory…](command:jpipe.addExcludedDirectory)"
                     }
                 }
             },

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -153,6 +153,12 @@
                 "icon": "$(check)"
             },
             {
+                "command": "jpipe.installFromRelease",
+                "title": "Install Compiler from GitHub Release",
+                "category": "jPipe",
+                "icon": "$(cloud-download)"
+            },
+            {
                 "command": "jpipe.addExcludedDirectory",
                 "title": "Add Excluded Directory",
                 "category": "jPipe",
@@ -223,14 +229,16 @@
                     "type": "string",
                     "enum": [
                         "cli",
-                        "jar"
+                        "jar",
+                        "managed"
                     ],
                     "enumDescriptions": [
                         "Use the jpipe CLI executable (recommended). Configure the path below with 'CLI: Path'.",
-                        "Use a JAR file (manual installation / developer mode). Configure the path below with 'JAR: File' and 'JAR: Java Executable'."
+                        "Use a JAR file (manual installation / developer mode). Configure the path below with 'JAR: File' and 'JAR: Java Executable'.",
+                        "Use a compiler the extension downloads and manages from GitHub Releases. Install or switch versions via the 'Install Compiler from GitHub Release' command (requires Java)."
                     ],
                     "default": "cli",
-                    "markdownDescription": "How to invoke the jPipe compiler. Choose **cli** (recommended) or **jar** (manual installation).\n\n[Check jPipe installation](command:jpipe.checkInstallation)"
+                    "markdownDescription": "How to invoke the jPipe compiler. Choose **cli** (recommended), **jar** (manual installation), or **managed** (downloaded automatically from GitHub Releases — easiest on Windows).\n\n[$(cloud-download) Install from GitHub Release](command:jpipe.installFromRelease) · [Check jPipe installation](command:jpipe.checkInstallation)"
                 },
                 "jpipe.cliPath": {
                     "order": 2,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -238,7 +238,7 @@
                         "Use a compiler the extension downloads and manages from GitHub Releases. Install or switch versions via the 'Install Compiler from GitHub Release' command (requires Java)."
                     ],
                     "default": "cli",
-                    "markdownDescription": "How to invoke the jPipe compiler. Choose **cli** (recommended), **jar** (manual installation), or **managed** (downloaded automatically from GitHub Releases — easiest on Windows).\n\n[$(cloud-download) Install from GitHub Release](command:jpipe.installFromRelease) · [Check jPipe installation](command:jpipe.checkInstallation)"
+                    "markdownDescription": "How to invoke the jPipe compiler. Choose **cli** (recommended), **jar** (manual installation), or **managed** (downloaded automatically from GitHub Releases — easiest on Windows).\n\n[Install from GitHub Release](command:jpipe.installFromRelease) · [Check jPipe installation](command:jpipe.checkInstallation)"
                 },
                 "jpipe.cliPath": {
                     "order": 2,

--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
@@ -7,7 +7,10 @@ import * as os from 'node:os';
 import { JpipeLogger } from '../logger.js';
 import { ReleaseManager } from './release-manager.js';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+/** Generous stdout cap so large SVG renders are not truncated (default is only 1 MB). */
+const MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
 
 /** Fallback invocation timeout (seconds) when `jpipe.compilerTimeout` is unset. */
 const DEFAULT_TIMEOUT_SECONDS = 30;
@@ -36,8 +39,10 @@ function envWithPath(): NodeJS.ProcessEnv {
     const extra = vscode.workspace.getConfiguration('jpipe').get<string[]>('extraPath', []) ?? [];
     const defaults = ['/opt/homebrew/bin', '/usr/local/bin'];
     const existing = process.env.PATH ?? '';
-    const prefix = [...extra.filter(Boolean), ...defaults].join(path.delimiter);
-    return { ...process.env, PATH: `${prefix}${path.delimiter}${existing}` };
+    // Trim and drop empties so we never introduce an empty PATH segment (which POSIX
+    // shells treat as the current directory — a security footgun) or a trailing delimiter.
+    const segments = [...extra, ...defaults, existing].map(s => s.trim()).filter(Boolean);
+    return { ...process.env, PATH: segments.join(path.delimiter) };
 }
 
 export enum ImageFormat {
@@ -61,18 +66,19 @@ export class ImageGenerator {
     ) {}
 
     /**
-     * Resolve the command prefix (everything before the subcommand) for the configured
-     * execution mode: the resolved CLI, or `"java" -jar "<jar>"` for `jar` / `managed`.
-     * Throws with a user-facing message when the selected mode is misconfigured.
+     * Resolve the executable and its leading arguments for the configured execution mode:
+     * the CLI (`{ file: cli, args: [] }`), or `java [jvmArgs…] -jar <jar>` for `jar` / `managed`.
+     * Returned as an argv pair so callers can invoke via `execFile` (no shell) — user/workspace
+     * settings are never interpreted by a shell. Throws a user-facing message when misconfigured.
      */
-    private async resolveExecPrefix(config: vscode.WorkspaceConfiguration): Promise<string> {
+    private resolveExecCommand(config: vscode.WorkspaceConfiguration): { file: string; args: string[] } {
         const mode = config.get<string>('executionMode', 'cli');
 
         if (mode === 'jar') {
             const jarFile = expandTilde((config.get<string>('jarFile', '') ?? '').trim());
             if (!jarFile) throw new Error('jpipe.jarFile is not configured.');
             if (!fs.existsSync(jarFile)) throw new Error(`JAR file not found: ${jarFile}`);
-            return this.buildJarPrefix(config, jarFile);
+            return this.buildJarCommand(config, jarFile);
         }
 
         if (mode === 'managed') {
@@ -83,31 +89,20 @@ export class ImageGenerator {
             if (!fs.existsSync(installed.jarPath)) {
                 throw new Error(`Managed JAR file not found: ${installed.jarPath}`);
             }
-            return this.buildJarPrefix(config, installed.jarPath);
+            return this.buildJarCommand(config, installed.jarPath);
         }
 
-        // cli mode: resolve a bare name via `which`, otherwise use the given path as-is.
+        // cli mode: a bare name is resolved via PATH by execFile; a path is used directly.
         const cliPath = (config.get<string>('cliPath', 'jpipe') ?? 'jpipe').trim();
-        if (path.isAbsolute(cliPath) || cliPath.includes(path.sep)) {
-            return `"${path.normalize(cliPath)}"`;
-        }
-        try {
-            const { stdout } = await execAsync(`which ${cliPath}`, { env: envWithPath() });
-            const cliCmd = stdout.trim();
-            this.logger.debug(`Resolved CLI '${cliPath}' → ${cliCmd}`);
-            return `"${cliCmd}"`;
-        } catch {
-            this.logger.debug(`'which ${cliPath}' failed, using bare name`);
-            return `"${cliPath}"`;
-        }
+        const file = (path.isAbsolute(cliPath) || cliPath.includes(path.sep)) ? path.normalize(cliPath) : cliPath;
+        return { file, args: [] };
     }
 
-    /** Build the `"java" [jvmArgs…] -jar "<jar>"` prefix shared by the `jar` and `managed` modes. */
-    private buildJarPrefix(config: vscode.WorkspaceConfiguration, jarFile: string): string {
+    /** Build the `java [jvmArgs…] -jar <jar>` argv shared by the `jar` and `managed` modes. */
+    private buildJarCommand(config: vscode.WorkspaceConfiguration, jarFile: string): { file: string; args: string[] } {
         const javaExecutable = (config.get<string>('javaExecutable', 'java') ?? 'java').trim();
-        const jvmArgs = (config.get<string[]>('jvmArgs', []) ?? []).filter(Boolean);
-        const argsPart = jvmArgs.length ? ` ${jvmArgs.join(' ')}` : '';
-        return `"${javaExecutable}"${argsPart} -jar "${path.normalize(jarFile)}"`;
+        const jvmArgs = (config.get<string[]>('jvmArgs', []) ?? []).map(a => a.trim()).filter(Boolean);
+        return { file: javaExecutable, args: [...jvmArgs, '-jar', path.normalize(jarFile)] };
     }
     
     /**
@@ -142,20 +137,23 @@ export class ImageGenerator {
         const diagramName = forcedDiagramName ?? this.findDiagramName(document, editor);
         
         const config = vscode.workspace.getConfiguration('jpipe');
-        const inputArg = `-i "${path.normalize(inputFile)}"`;
-        const modelArg = `-m ${diagramName}`;
-        const formatArg = `-f ${format.toString().toUpperCase()}`;
 
-        let command: string;
+        let resolved: { file: string; args: string[] };
         try {
-            const prefix = await this.resolveExecPrefix(config);
-            command = `${prefix} process ${inputArg} ${modelArg} ${formatArg}`;
+            resolved = this.resolveExecCommand(config);
         } catch (e: any) {
             vscode.window.showErrorMessage(e.message);
             throw e;
         }
 
-        this.lastExportUri = undefined;
+        const argv = [
+            ...resolved.args,
+            'process',
+            '-i', path.normalize(inputFile),
+            '-m', diagramName,
+            '-f', format.toString().toUpperCase(),
+        ];
+
         if (saveToFile) {
             const outputPath = await this.promptForSaveLocation(document, diagramName, format);
             if (!outputPath) {
@@ -163,14 +161,15 @@ export class ImageGenerator {
                 e.cancelled = true;
                 throw e;
             }
-            command += ` -o "${outputPath.fsPath}"`;
+            argv.push('-o', outputPath.fsPath);
+            // Recorded only on the save path so a concurrent preview render can't clear it.
             this.lastExportUri = outputPath;
         }
 
-        this.logger.info(`Executing: ${command}`);
+        this.logger.info(`Executing: ${resolved.file} ${argv.join(' ')}`);
 
         try {
-            const { stdout } = await execAsync(command, { env: envWithPath(), timeout: timeoutMs(config) });
+            const { stdout } = await execFileAsync(resolved.file, argv, { env: envWithPath(), timeout: timeoutMs(config), maxBuffer: MAX_OUTPUT_BYTES });
             this.logger.info(`Generated ${format} for '${diagramName}' (${path.basename(document.uri.fsPath)})`);
             return stdout;
         } catch (error: any) {
@@ -191,16 +190,15 @@ export class ImageGenerator {
     public async check(): Promise<{ ok: boolean; message: string }> {
         const config = vscode.workspace.getConfiguration('jpipe');
 
-        let command: string;
+        let resolved: { file: string; args: string[] };
         try {
-            const prefix = await this.resolveExecPrefix(config);
-            command = `${prefix} --headless doctor`;
+            resolved = this.resolveExecCommand(config);
         } catch (e: any) {
             return { ok: false, message: e.message };
         }
 
         try {
-            const { stdout, stderr } = await execAsync(command, { env: envWithPath(), timeout: timeoutMs(config) });
+            const { stdout, stderr } = await execFileAsync(resolved.file, [...resolved.args, '--headless', 'doctor'], { env: envWithPath(), timeout: timeoutMs(config), maxBuffer: MAX_OUTPUT_BYTES });
             const output = (stdout + stderr).trim();
             return { ok: true, message: output || 'jPipe is accessible.' };
         } catch (error: any) {
@@ -212,19 +210,18 @@ export class ImageGenerator {
     public async generateDiagnostic(document: vscode.TextDocument): Promise<string> {
         const inputFile = path.normalize(document.uri.fsPath);
         const config = vscode.workspace.getConfiguration('jpipe');
-        const inputArg = `-i "${inputFile}"`;
 
-        let command: string;
+        let resolved: { file: string; args: string[] };
         try {
-            const prefix = await this.resolveExecPrefix(config);
-            command = `${prefix} diagnostic ${inputArg}`;
+            resolved = this.resolveExecCommand(config);
         } catch (e: any) {
             return e.message;
         }
 
-        this.logger.info(`Executing: ${command}`);
+        const argv = [...resolved.args, 'diagnostic', '-i', inputFile];
+        this.logger.info(`Executing: ${resolved.file} ${argv.join(' ')}`);
         try {
-            const { stdout, stderr } = await execAsync(command, { env: envWithPath(), timeout: timeoutMs(config) });
+            const { stdout, stderr } = await execFileAsync(resolved.file, argv, { env: envWithPath(), timeout: timeoutMs(config), maxBuffer: MAX_OUTPUT_BYTES });
             return [stdout, stderr].filter(Boolean).join('\n').trim() || '(no output)';
         } catch (e: any) {
             const out = (e.stdout ?? '').trim();

--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import { JpipeLogger } from '../logger.js';
+import { ReleaseManager } from './release-manager.js';
 
 const execAsync = promisify(exec);
 
@@ -39,7 +40,58 @@ export enum ImageFormat {
 
 export class ImageGenerator {
 
-    constructor(private readonly logger: JpipeLogger) {}
+    constructor(
+        private readonly logger: JpipeLogger,
+        private readonly releaseManager: ReleaseManager
+    ) {}
+
+    /**
+     * Resolve the command prefix (everything before the subcommand) for the configured
+     * execution mode: the resolved CLI, or `"java" -jar "<jar>"` for `jar` / `managed`.
+     * Throws with a user-facing message when the selected mode is misconfigured.
+     */
+    private async resolveExecPrefix(config: vscode.WorkspaceConfiguration): Promise<string> {
+        const mode = config.get<string>('executionMode', 'cli');
+
+        if (mode === 'jar') {
+            const jarFile = expandTilde((config.get<string>('jarFile', '') ?? '').trim());
+            if (!jarFile) throw new Error('jpipe.jarFile is not configured.');
+            if (!fs.existsSync(jarFile)) throw new Error(`JAR file not found: ${jarFile}`);
+            return this.buildJarPrefix(config, jarFile);
+        }
+
+        if (mode === 'managed') {
+            const installed = this.releaseManager.getInstalled();
+            if (!installed) {
+                throw new Error("No managed jPipe compiler installed. Run 'jPipe: Install Compiler from GitHub Release'.");
+            }
+            if (!fs.existsSync(installed.jarPath)) {
+                throw new Error(`Managed JAR file not found: ${installed.jarPath}`);
+            }
+            return this.buildJarPrefix(config, installed.jarPath);
+        }
+
+        // cli mode: resolve a bare name via `which`, otherwise use the given path as-is.
+        const cliPath = (config.get<string>('cliPath', 'jpipe') ?? 'jpipe').trim();
+        if (path.isAbsolute(cliPath) || cliPath.includes(path.sep)) {
+            return `"${path.normalize(cliPath)}"`;
+        }
+        try {
+            const { stdout } = await execAsync(`which ${cliPath}`, { env: envWithPath() });
+            const cliCmd = stdout.trim();
+            this.logger.debug(`Resolved CLI '${cliPath}' → ${cliCmd}`);
+            return `"${cliCmd}"`;
+        } catch {
+            this.logger.debug(`'which ${cliPath}' failed, using bare name`);
+            return `"${cliPath}"`;
+        }
+    }
+
+    /** Build the `"java" -jar "<jar>"` prefix shared by the `jar` and `managed` modes. */
+    private buildJarPrefix(config: vscode.WorkspaceConfiguration, jarFile: string): string {
+        const javaExecutable = (config.get<string>('javaExecutable', 'java') ?? 'java').trim();
+        return `"${javaExecutable}" -jar "${path.normalize(jarFile)}"`;
+    }
     
     /**
      * Generate an image from the active jpipe file or provided document
@@ -73,41 +125,17 @@ export class ImageGenerator {
         const diagramName = forcedDiagramName ?? this.findDiagramName(document, editor);
         
         const config = vscode.workspace.getConfiguration('jpipe');
-        const mode = config.get<string>('executionMode', 'cli');
-
-        let command: string;
         const inputArg = `-i "${path.normalize(inputFile)}"`;
         const modelArg = `-m ${diagramName}`;
         const formatArg = `-f ${format.toString().toUpperCase()}`;
 
-        if (mode === 'jar') {
-            const jarFile = expandTilde((config.get<string>('jarFile', '') ?? '').trim());
-            const javaExecutable = (config.get<string>('javaExecutable', 'java') ?? 'java').trim();
-            if (!jarFile) {
-                vscode.window.showErrorMessage('Please set jpipe.jarFile in settings.');
-                throw new Error('jpipe.jarFile is not configured.');
-            }
-            if (!fs.existsSync(jarFile)) {
-                vscode.window.showErrorMessage(`JAR file not found: ${jarFile}`);
-                throw new Error(`JAR file not found: ${jarFile}`);
-            }
-            command = `"${javaExecutable}" -jar "${path.normalize(jarFile)}" process ${inputArg} ${modelArg} ${formatArg}`;
-        } else {
-            const cliPath = (config.get<string>('cliPath', 'jpipe') ?? 'jpipe').trim();
-            let cliCmd: string;
-            if (path.isAbsolute(cliPath) || cliPath.includes(path.sep)) {
-                cliCmd = path.normalize(cliPath);
-            } else {
-                try {
-                    const { stdout } = await execAsync(`which ${cliPath}`, { env: envWithPath() });
-                    cliCmd = stdout.trim();
-                    this.logger.debug(`Resolved CLI '${cliPath}' → ${cliCmd}`);
-                } catch {
-                    cliCmd = cliPath;
-                    this.logger.debug(`'which ${cliPath}' failed, using bare name`);
-                }
-            }
-            command = `"${cliCmd}" process ${inputArg} ${modelArg} ${formatArg}`;
+        let command: string;
+        try {
+            const prefix = await this.resolveExecPrefix(config);
+            command = `${prefix} process ${inputArg} ${modelArg} ${formatArg}`;
+        } catch (e: any) {
+            vscode.window.showErrorMessage(e.message);
+            throw e;
         }
 
         if (saveToFile) {
@@ -143,29 +171,13 @@ export class ImageGenerator {
      */
     public async check(): Promise<{ ok: boolean; message: string }> {
         const config = vscode.workspace.getConfiguration('jpipe');
-        const mode = config.get<string>('executionMode', 'cli');
 
         let command: string;
-        if (mode === 'jar') {
-            const jarFile = expandTilde((config.get<string>('jarFile', '') ?? '').trim());
-            const javaExecutable = (config.get<string>('javaExecutable', 'java') ?? 'java').trim();
-            if (!jarFile) return { ok: false, message: 'jpipe.jarFile is not configured.' };
-            if (!fs.existsSync(jarFile)) return { ok: false, message: `JAR file not found: ${jarFile}` };
-            command = `"${javaExecutable}" -jar "${path.normalize(jarFile)}" --headless doctor`;
-        } else {
-            const cliPath = (config.get<string>('cliPath', 'jpipe') ?? 'jpipe').trim();
-            let cliCmd: string;
-            if (path.isAbsolute(cliPath) || cliPath.includes(path.sep)) {
-                cliCmd = path.normalize(cliPath);
-            } else {
-                try {
-                    const { stdout } = await execAsync(`which ${cliPath}`, { env: envWithPath() });
-                    cliCmd = stdout.trim();
-                } catch {
-                    cliCmd = cliPath;
-                }
-            }
-            command = `"${cliCmd}" --headless doctor`;
+        try {
+            const prefix = await this.resolveExecPrefix(config);
+            command = `${prefix} --headless doctor`;
+        } catch (e: any) {
+            return { ok: false, message: e.message };
         }
 
         try {
@@ -181,31 +193,14 @@ export class ImageGenerator {
     public async generateDiagnostic(document: vscode.TextDocument): Promise<string> {
         const inputFile = path.normalize(document.uri.fsPath);
         const config = vscode.workspace.getConfiguration('jpipe');
-        const mode = config.get<string>('executionMode', 'cli');
-
-        let command: string;
         const inputArg = `-i "${inputFile}"`;
 
-        if (mode === 'jar') {
-            const jarFile = expandTilde((config.get<string>('jarFile', '') ?? '').trim());
-            const javaExecutable = (config.get<string>('javaExecutable', 'java') ?? 'java').trim();
-            if (!jarFile) return 'jpipe.jarFile is not configured.';
-            if (!fs.existsSync(jarFile)) return `JAR file not found: ${jarFile}`;
-            command = `"${javaExecutable}" -jar "${path.normalize(jarFile)}" diagnostic ${inputArg}`;
-        } else {
-            const cliPath = (config.get<string>('cliPath', 'jpipe') ?? 'jpipe').trim();
-            let cliCmd: string;
-            if (path.isAbsolute(cliPath) || cliPath.includes(path.sep)) {
-                cliCmd = path.normalize(cliPath);
-            } else {
-                try {
-                    const { stdout } = await execAsync(`which ${cliPath}`, { env: envWithPath() });
-                    cliCmd = stdout.trim();
-                } catch {
-                    cliCmd = cliPath;
-                }
-            }
-            command = `"${cliCmd}" diagnostic ${inputArg}`;
+        let command: string;
+        try {
+            const prefix = await this.resolveExecPrefix(config);
+            command = `${prefix} diagnostic ${inputArg}`;
+        } catch (e: any) {
+            return e.message;
         }
 
         this.logger.info(`Executing: ${command}`);

--- a/packages/extension/src/extension/image-generation/image-generator.ts
+++ b/packages/extension/src/extension/image-generation/image-generator.ts
@@ -9,9 +9,15 @@ import { ReleaseManager } from './release-manager.js';
 
 const execAsync = promisify(exec);
 
-/** Max time (ms) to wait for a jPipe CLI/JAR invocation before giving up, so a hung
+/** Fallback invocation timeout (seconds) when `jpipe.compilerTimeout` is unset. */
+const DEFAULT_TIMEOUT_SECONDS = 30;
+
+/** Max time (ms) to wait for a compiler invocation before giving up, so a hung
  *  compiler surfaces an error instead of freezing the preview panel indefinitely. */
-const CLI_TIMEOUT_MS = 30_000;
+function timeoutMs(config: vscode.WorkspaceConfiguration): number {
+    const seconds = config.get<number>('compilerTimeout', DEFAULT_TIMEOUT_SECONDS);
+    return (typeof seconds === 'number' && seconds > 0 ? seconds : DEFAULT_TIMEOUT_SECONDS) * 1000;
+}
 
 /** Expand leading ~ to the user's home directory (Node does not do this by default). */
 function expandTilde(filePath: string): string {
@@ -21,11 +27,17 @@ function expandTilde(filePath: string): string {
     return filePath;
 }
 
-/** PATH that includes Homebrew so script shebangs (e.g. #!/usr/bin/env python3) can find interpreters. */
+/**
+ * PATH augmented so the compiler can find external interpreters (e.g. `python3`, `dot`):
+ * user-configured `jpipe.extraPath` entries first, then the built-in Homebrew defaults,
+ * then the inherited PATH.
+ */
 function envWithPath(): NodeJS.ProcessEnv {
-    const prefix = '/opt/homebrew/bin:/usr/local/bin:';
+    const extra = vscode.workspace.getConfiguration('jpipe').get<string[]>('extraPath', []) ?? [];
+    const defaults = ['/opt/homebrew/bin', '/usr/local/bin'];
     const existing = process.env.PATH ?? '';
-    return { ...process.env, PATH: prefix + existing };
+    const prefix = [...extra.filter(Boolean), ...defaults].join(path.delimiter);
+    return { ...process.env, PATH: `${prefix}${path.delimiter}${existing}` };
 }
 
 export enum ImageFormat {
@@ -39,6 +51,9 @@ export enum ImageFormat {
 }
 
 export class ImageGenerator {
+
+    /** Destination of the most recent save-to-file generate(), so generateAndSave can open it. */
+    private lastExportUri: vscode.Uri | undefined;
 
     constructor(
         private readonly logger: JpipeLogger,
@@ -87,10 +102,12 @@ export class ImageGenerator {
         }
     }
 
-    /** Build the `"java" -jar "<jar>"` prefix shared by the `jar` and `managed` modes. */
+    /** Build the `"java" [jvmArgs…] -jar "<jar>"` prefix shared by the `jar` and `managed` modes. */
     private buildJarPrefix(config: vscode.WorkspaceConfiguration, jarFile: string): string {
         const javaExecutable = (config.get<string>('javaExecutable', 'java') ?? 'java').trim();
-        return `"${javaExecutable}" -jar "${path.normalize(jarFile)}"`;
+        const jvmArgs = (config.get<string[]>('jvmArgs', []) ?? []).filter(Boolean);
+        const argsPart = jvmArgs.length ? ` ${jvmArgs.join(' ')}` : '';
+        return `"${javaExecutable}"${argsPart} -jar "${path.normalize(jarFile)}"`;
     }
     
     /**
@@ -138,6 +155,7 @@ export class ImageGenerator {
             throw e;
         }
 
+        this.lastExportUri = undefined;
         if (saveToFile) {
             const outputPath = await this.promptForSaveLocation(document, diagramName, format);
             if (!outputPath) {
@@ -146,12 +164,13 @@ export class ImageGenerator {
                 throw e;
             }
             command += ` -o "${outputPath.fsPath}"`;
+            this.lastExportUri = outputPath;
         }
 
         this.logger.info(`Executing: ${command}`);
 
         try {
-            const { stdout } = await execAsync(command, { env: envWithPath(), timeout: CLI_TIMEOUT_MS });
+            const { stdout } = await execAsync(command, { env: envWithPath(), timeout: timeoutMs(config) });
             this.logger.info(`Generated ${format} for '${diagramName}' (${path.basename(document.uri.fsPath)})`);
             return stdout;
         } catch (error: any) {
@@ -181,7 +200,7 @@ export class ImageGenerator {
         }
 
         try {
-            const { stdout, stderr } = await execAsync(command, { env: envWithPath(), timeout: CLI_TIMEOUT_MS });
+            const { stdout, stderr } = await execAsync(command, { env: envWithPath(), timeout: timeoutMs(config) });
             const output = (stdout + stderr).trim();
             return { ok: true, message: output || 'jPipe is accessible.' };
         } catch (error: any) {
@@ -205,7 +224,7 @@ export class ImageGenerator {
 
         this.logger.info(`Executing: ${command}`);
         try {
-            const { stdout, stderr } = await execAsync(command, { env: envWithPath(), timeout: CLI_TIMEOUT_MS });
+            const { stdout, stderr } = await execAsync(command, { env: envWithPath(), timeout: timeoutMs(config) });
             return [stdout, stderr].filter(Boolean).join('\n').trim() || '(no output)';
         } catch (e: any) {
             const out = (e.stdout ?? '').trim();
@@ -218,6 +237,10 @@ export class ImageGenerator {
         try {
             await this.generate(true, format, document, forcedDiagramName);
             vscode.window.showInformationMessage(`${format} saved successfully`);
+            const openAfter = vscode.workspace.getConfiguration('jpipe').get<boolean>('openAfterExport', false);
+            if (openAfter && this.lastExportUri) {
+                void vscode.commands.executeCommand('vscode.open', this.lastExportUri);
+            }
         } catch (error: any) {
             if (error?.cancelled === true || String(error?.message ?? '') === 'Save cancelled') {
                 return;

--- a/packages/extension/src/extension/image-generation/index.ts
+++ b/packages/extension/src/extension/image-generation/index.ts
@@ -1,2 +1,3 @@
 export * from "./image-generator.js";
 export * from "./preview-provider.js";
+export * from "./release-manager.js";

--- a/packages/extension/src/extension/image-generation/release-manager.ts
+++ b/packages/extension/src/extension/image-generation/release-manager.ts
@@ -52,32 +52,61 @@ function isAllowedHost(host: string): boolean {
     return ALLOWED_HOSTS.has(host) || host.endsWith('.githubusercontent.com');
 }
 
-/** Parse a release tag like `v2.1.0` / `2.0.0` into its major/minor/patch, or undefined. */
-function parseSemver(tag: string): [number, number, number] | undefined {
-    const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(tag.trim());
-    if (!m) return undefined;
-    return [Number(m[1]), Number(m[2]), Number(m[3])];
+interface Version {
+    nums: [number, number, number];
+    /** Prerelease identifiers (e.g. `rc.1`), or undefined for a stable release. */
+    pre: string | undefined;
 }
 
-/** Sort comparator: newest semver first. */
-function compareSemverDesc(a: JpipeRelease, b: JpipeRelease): number {
-    const sa = parseSemver(a.tag) ?? [0, 0, 0];
-    const sb = parseSemver(b.tag) ?? [0, 0, 0];
-    for (let i = 0; i < 3; i++) {
-        if (sb[i] !== sa[i]) return sb[i] - sa[i];
+/** Parse a release tag like `v2.1.0` or `v2.0.0-rc1` into its core version + prerelease. */
+function parseSemver(tag: string): Version | undefined {
+    const m = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(tag.trim());
+    if (!m) return undefined;
+    return { nums: [Number(m[1]), Number(m[2]), Number(m[3])], pre: m[4] };
+}
+
+/** Compare two prerelease strings per semver identifier rules (numeric < alphanumeric). */
+function comparePreRelease(a: string, b: string): number {
+    const as = a.split('.');
+    const bs = b.split('.');
+    for (let i = 0; i < Math.max(as.length, bs.length); i++) {
+        const x = as[i];
+        const y = bs[i];
+        if (x === undefined) return -1; // fewer identifiers = lower precedence
+        if (y === undefined) return 1;
+        const xn = /^\d+$/.test(x);
+        const yn = /^\d+$/.test(y);
+        if (xn && yn) { const d = Number(x) - Number(y); if (d !== 0) return Math.sign(d); }
+        else if (xn) return -1;
+        else if (yn) return 1;
+        else if (x !== y) return x < y ? -1 : 1;
     }
     return 0;
 }
 
-/** True when `candidate` is a strictly higher semver than `baseline`. */
-function isStrictlyNewer(candidate: string, baseline: string): boolean {
-    const c = parseSemver(candidate);
-    const b = parseSemver(baseline);
-    if (!c || !b) return false;
+/** Full semver precedence: >0 if `a` is newer than `b`, <0 if older, 0 if equal. */
+function comparePrecedence(a: string, b: string): number {
+    const va = parseSemver(a);
+    const vb = parseSemver(b);
+    if (!va || !vb) return 0;
     for (let i = 0; i < 3; i++) {
-        if (c[i] !== b[i]) return c[i] > b[i];
+        if (va.nums[i] !== vb.nums[i]) return va.nums[i] - vb.nums[i];
     }
-    return false;
+    // Same core version: a stable release outranks a prerelease of that version.
+    if (va.pre === undefined && vb.pre === undefined) return 0;
+    if (va.pre === undefined) return 1;
+    if (vb.pre === undefined) return -1;
+    return comparePreRelease(va.pre, vb.pre);
+}
+
+/** Sort comparator: newest version first (stable ahead of its own prereleases). */
+function compareSemverDesc(a: JpipeRelease, b: JpipeRelease): number {
+    return comparePrecedence(b.tag, a.tag);
+}
+
+/** True when `candidate` has strictly higher precedence than `baseline`. */
+function isStrictlyNewer(candidate: string, baseline: string): boolean {
+    return comparePrecedence(candidate, baseline) > 0;
 }
 
 /**
@@ -111,7 +140,7 @@ export class ReleaseManager {
             if (rel?.prerelease && !includePrereleases) continue;
             const tag: string = rel?.tag_name ?? '';
             const semver = parseSemver(tag);
-            if (!semver || semver[0] < MIN_MAJOR) continue;
+            if (!semver || semver.nums[0] < MIN_MAJOR) continue;
 
             const assets: any[] = Array.isArray(rel?.assets) ? rel.assets : [];
             const jar = assets.find(a => CLI_JAR_RE.test(a?.name ?? ''));
@@ -184,16 +213,19 @@ export class ReleaseManager {
     }
 
     /**
-     * If a managed compiler is installed and a strictly-newer stable release exists, show a
-     * non-blocking notification offering to update. Throttled to once per day and
+     * If the extension is in managed mode with a compiler installed and a strictly-newer
+     * release exists, show a non-blocking notification offering to update. Throttled and
      * silent on any failure (this runs opportunistically at activation).
      */
     public async maybeNotifyUpdate(runInstall: (preselectTag: string) => Promise<void>): Promise<void> {
+        const config = vscode.workspace.getConfiguration('jpipe');
+        // Managed-mode only: don't prompt when the user is running cli/jar even if a
+        // managed jar happens to be installed (matches jpipe.managedCheckForUpdates' scope).
+        if (config.get<string>('executionMode', 'cli') !== 'managed') return;
+        if (!config.get<boolean>('managedCheckForUpdates', true)) return;
+
         const installed = this.getInstalled();
         if (!installed) return;
-
-        const config = vscode.workspace.getConfiguration('jpipe');
-        if (!config.get<boolean>('managedCheckForUpdates', true)) return;
 
         const hours = config.get<number>('managedUpdateCheckIntervalHours', DEFAULT_UPDATE_INTERVAL_HOURS);
         const intervalMs = (typeof hours === 'number' && hours > 0 ? hours : DEFAULT_UPDATE_INTERVAL_HOURS) * 3_600_000;

--- a/packages/extension/src/extension/image-generation/release-manager.ts
+++ b/packages/extension/src/extension/image-generation/release-manager.ts
@@ -159,6 +159,9 @@ export class ReleaseManager {
             await fs.promises.rm(partPath, { force: true });
             throw new Error(`Downloaded jar size mismatch for ${release.tag} (expected ${release.jarSize} bytes).`);
         }
+        // Remove any stale/partial file at the destination first: fs.rename fails on
+        // Windows when the target already exists, which would block re-download/retry.
+        await fs.promises.rm(destPath, { force: true });
         await fs.promises.rename(partPath, destPath);
         this.logger.info(`Installed jPipe ${release.tag} → ${destPath} (sha256: ${sha256})`);
         return destPath;
@@ -218,7 +221,12 @@ export class ReleaseManager {
     /** The `owner/repo` releases are pulled from (configurable for forks/testing). */
     private repo(): string {
         const configured = (vscode.workspace.getConfiguration('jpipe').get<string>('managedRepository', DEFAULT_RELEASE_REPO) ?? '').trim();
-        return configured || DEFAULT_RELEASE_REPO;
+        // Accept only a strict owner/repo slug; anything else could distort the API URL.
+        if (/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(configured)) return configured;
+        if (configured && configured !== DEFAULT_RELEASE_REPO) {
+            this.logger.warn(`Ignoring invalid jpipe.managedRepository '${configured}'; using ${DEFAULT_RELEASE_REPO}.`);
+        }
+        return DEFAULT_RELEASE_REPO;
     }
 
     private compilerRoot(): string {

--- a/packages/extension/src/extension/image-generation/release-manager.ts
+++ b/packages/extension/src/extension/image-generation/release-manager.ts
@@ -1,0 +1,343 @@
+import * as vscode from 'vscode';
+import * as https from 'node:https';
+import type { IncomingMessage } from 'node:http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import { JpipeLogger } from '../logger.js';
+
+/** GitHub repository that publishes the jPipe compiler releases. */
+const RELEASE_REPO = 'jpipe-mcscert/jpipe-compiler';
+
+/** Only 2.x+ releases expose the `process` / `diagnostic` / `--headless doctor` subcommands
+ *  the extension drives; older `jpipe.jar` releases predate them and are hidden. */
+const MIN_MAJOR = 2;
+
+/** Asset name of the CLI jar in a 2.x release, e.g. `jpipe-cli-2.1.0.jar`. */
+const CLI_JAR_RE = /^jpipe-cli-.*\.jar$/;
+
+/** Hosts we are willing to talk to. Any redirect outside this set is rejected. */
+const ALLOWED_HOSTS = new Set([
+    'api.github.com',
+    'github.com',
+    'objects.githubusercontent.com',
+]);
+
+/** globalState keys. */
+const KEY_INSTALLED = 'jpipe.managedCompiler';
+const KEY_LAST_CHECK = 'jpipe.managedCompiler.lastUpdateCheck';
+
+/** Only check for a newer release once per this window (ms). */
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Follow at most this many HTTP redirects before giving up. */
+const MAX_REDIRECTS = 5;
+
+export interface JpipeRelease {
+    tag: string;
+    name: string;
+    publishedAt: string;
+    jarUrl: string;
+    jarName: string;
+    jarSize: number;
+}
+
+interface InstalledCompiler {
+    tag: string;
+    jarPath: string;
+}
+
+/** True for `objects.githubusercontent.com` and any `*.githubusercontent.com` subdomain. */
+function isAllowedHost(host: string): boolean {
+    return ALLOWED_HOSTS.has(host) || host.endsWith('.githubusercontent.com');
+}
+
+/** Parse a release tag like `v2.1.0` / `2.0.0` into its major/minor/patch, or undefined. */
+function parseSemver(tag: string): [number, number, number] | undefined {
+    const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(tag.trim());
+    if (!m) return undefined;
+    return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** Sort comparator: newest semver first. */
+function compareSemverDesc(a: JpipeRelease, b: JpipeRelease): number {
+    const sa = parseSemver(a.tag) ?? [0, 0, 0];
+    const sb = parseSemver(b.tag) ?? [0, 0, 0];
+    for (let i = 0; i < 3; i++) {
+        if (sb[i] !== sa[i]) return sb[i] - sa[i];
+    }
+    return 0;
+}
+
+/** True when `candidate` is a strictly higher semver than `baseline`. */
+function isStrictlyNewer(candidate: string, baseline: string): boolean {
+    const c = parseSemver(candidate);
+    const b = parseSemver(baseline);
+    if (!c || !b) return false;
+    for (let i = 0; i < 3; i++) {
+        if (c[i] !== b[i]) return c[i] > b[i];
+    }
+    return false;
+}
+
+/**
+ * Downloads, stores, and tracks a jPipe compiler jar pulled from the GitHub releases page,
+ * so the "managed" execution mode can run it without the user wiring up a path by hand.
+ */
+export class ReleaseManager {
+
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly logger: JpipeLogger
+    ) {}
+
+    /** List installable (stable, v2.0.0+) releases, newest first. Throws on network/API failure. */
+    public async listReleases(): Promise<JpipeRelease[]> {
+        const url = `https://api.github.com/repos/${RELEASE_REPO}/releases?per_page=100`;
+        const raw = await this.httpsGetJson(url);
+        if (!Array.isArray(raw)) {
+            throw new Error('Unexpected response from the GitHub releases API.');
+        }
+
+        const releases: JpipeRelease[] = [];
+        for (const rel of raw as any[]) {
+            if (rel?.draft || rel?.prerelease) continue;
+            const tag: string = rel?.tag_name ?? '';
+            const semver = parseSemver(tag);
+            if (!semver || semver[0] < MIN_MAJOR) continue;
+
+            const assets: any[] = Array.isArray(rel?.assets) ? rel.assets : [];
+            const jar = assets.find(a => CLI_JAR_RE.test(a?.name ?? ''));
+            if (!jar?.browser_download_url) continue;
+
+            releases.push({
+                tag,
+                name: rel?.name || tag,
+                publishedAt: rel?.published_at ?? '',
+                jarUrl: jar.browser_download_url,
+                jarName: jar.name,
+                jarSize: typeof jar.size === 'number' ? jar.size : 0,
+            });
+        }
+        releases.sort(compareSemverDesc);
+        this.logger.debug(`Found ${releases.length} installable jPipe release(s)`);
+        return releases;
+    }
+
+    /**
+     * Download the jar for `release` into hidden global storage and return its path.
+     * Idempotent: an already-present jar with the expected byte size is reused.
+     */
+    public async download(
+        release: JpipeRelease,
+        onProgress?: (fraction: number) => void
+    ): Promise<string> {
+        const destDir = path.join(this.compilerRoot(), release.tag);
+        const destPath = path.join(destDir, release.jarName);
+
+        if (fs.existsSync(destPath) && this.sizeMatches(destPath, release.jarSize)) {
+            this.logger.info(`Reusing already-downloaded jPipe ${release.tag}`);
+            return destPath;
+        }
+
+        await fs.promises.mkdir(destDir, { recursive: true });
+        const partPath = `${destPath}.part`;
+        await fs.promises.rm(partPath, { force: true });
+
+        this.logger.info(`Downloading jPipe ${release.tag} from ${release.jarUrl}`);
+        const sha256 = await this.httpsDownloadToFile(release.jarUrl, partPath, release.jarSize, onProgress);
+
+        // Verify the payload before making it visible under its final name.
+        if (release.jarSize > 0 && !this.sizeMatches(partPath, release.jarSize)) {
+            await fs.promises.rm(partPath, { force: true });
+            throw new Error(`Downloaded jar size mismatch for ${release.tag} (expected ${release.jarSize} bytes).`);
+        }
+        await fs.promises.rename(partPath, destPath);
+        this.logger.info(`Installed jPipe ${release.tag} → ${destPath} (sha256: ${sha256})`);
+        return destPath;
+    }
+
+    /** The currently installed managed compiler, or undefined if none / the file vanished. */
+    public getInstalled(): InstalledCompiler | undefined {
+        const installed = this.context.globalState.get<InstalledCompiler>(KEY_INSTALLED);
+        if (!installed?.jarPath) return undefined;
+        if (!fs.existsSync(installed.jarPath)) {
+            this.logger.warn(`Managed jPipe jar missing on disk: ${installed.jarPath}`);
+            return undefined;
+        }
+        return installed;
+    }
+
+    /** Record the active managed compiler. */
+    public async setInstalled(tag: string, jarPath: string): Promise<void> {
+        await this.context.globalState.update(KEY_INSTALLED, { tag, jarPath } satisfies InstalledCompiler);
+    }
+
+    /**
+     * If a managed compiler is installed and a strictly-newer stable release exists, show a
+     * non-blocking notification offering to update. Throttled to once per day and
+     * silent on any failure (this runs opportunistically at activation).
+     */
+    public async maybeNotifyUpdate(runInstall: (preselectTag: string) => Promise<void>): Promise<void> {
+        const installed = this.getInstalled();
+        if (!installed) return;
+
+        const last = this.context.globalState.get<number>(KEY_LAST_CHECK, 0);
+        if (Date.now() - last < UPDATE_CHECK_INTERVAL_MS) return;
+        await this.context.globalState.update(KEY_LAST_CHECK, Date.now());
+
+        try {
+            const releases = await this.listReleases();
+            const latest = releases[0]; // sorted newest-first
+            if (!latest || !isStrictlyNewer(latest.tag, installed.tag)) return;
+
+            const sel = await vscode.window.showInformationMessage(
+                `A newer jPipe compiler (${latest.tag}) is available. You have ${installed.tag}.`,
+                'Update'
+            );
+            if (sel === 'Update') await runInstall(latest.tag);
+        } catch (err) {
+            this.logger.debug(`Update check skipped: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    // ---- internals -------------------------------------------------------
+
+    private compilerRoot(): string {
+        return path.join(this.context.globalStorageUri.fsPath, 'compiler');
+    }
+
+    private sizeMatches(filePath: string, expected: number): boolean {
+        if (expected <= 0) return true; // API did not report a size; skip the check
+        try {
+            return fs.statSync(filePath).size === expected;
+        } catch {
+            return false;
+        }
+    }
+
+    /** HTTPS GET returning parsed JSON. Enforces host allowlist and follows redirects. */
+    private httpsGetJson(url: string, redirects = 0): Promise<unknown> {
+        return new Promise((resolve, reject) => {
+            this.get(url, redirects, reject, res => {
+                const status = res.statusCode ?? 0;
+                if (status >= 300 && status < 400 && res.headers.location) {
+                    res.resume();
+                    resolve(this.httpsGetJson(this.resolveRedirect(url, res.headers.location), redirects + 1));
+                    return;
+                }
+                if (status === 403) {
+                    res.resume();
+                    reject(new Error('GitHub API rate limit reached. Please try again later.'));
+                    return;
+                }
+                if (status !== 200) {
+                    res.resume();
+                    reject(new Error(`GitHub API request failed (HTTP ${status}).`));
+                    return;
+                }
+                const chunks: Buffer[] = [];
+                res.on('data', c => chunks.push(c as Buffer));
+                res.on('end', () => {
+                    try {
+                        resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+                    } catch {
+                        reject(new Error('Could not parse the GitHub API response.'));
+                    }
+                });
+                res.on('error', reject);
+            });
+        });
+    }
+
+    /** Stream a URL to `dest`, returning the payload's SHA-256. Enforces host allowlist + redirects. */
+    private httpsDownloadToFile(
+        url: string,
+        dest: string,
+        expectedSize: number,
+        onProgress?: (fraction: number) => void,
+        redirects = 0
+    ): Promise<string> {
+        return new Promise((resolve, reject) => {
+            this.get(url, redirects, reject, res => {
+                const status = res.statusCode ?? 0;
+                if (status >= 300 && status < 400 && res.headers.location) {
+                    res.resume();
+                    resolve(this.httpsDownloadToFile(
+                        this.resolveRedirect(url, res.headers.location), dest, expectedSize, onProgress, redirects + 1
+                    ));
+                    return;
+                }
+                if (status !== 200) {
+                    res.resume();
+                    reject(new Error(`Download failed (HTTP ${status}).`));
+                    return;
+                }
+
+                const total = expectedSize > 0
+                    ? expectedSize
+                    : Number(res.headers['content-length'] ?? 0);
+                const hash = crypto.createHash('sha256');
+                const file = fs.createWriteStream(dest);
+                let received = 0;
+
+                res.on('data', (chunk: Buffer) => {
+                    hash.update(chunk);
+                    received += chunk.length;
+                    if (onProgress && total > 0) onProgress(Math.min(received / total, 1));
+                });
+                res.pipe(file);
+                file.on('finish', () => file.close(() => resolve(hash.digest('hex'))));
+                file.on('error', err => fs.rm(dest, { force: true }, () => reject(err)));
+                res.on('error', err => fs.rm(dest, { force: true }, () => reject(err)));
+            });
+        });
+    }
+
+    /**
+     * Issue a validated HTTPS GET. Rejects non-HTTPS URLs, disallowed hosts, and excessive
+     * redirects *before* opening a socket, then invokes `onResponse` with the response.
+     */
+    private get(
+        url: string,
+        redirects: number,
+        onError: (err: Error) => void,
+        onResponse: (res: IncomingMessage) => void
+    ): void {
+        if (redirects > MAX_REDIRECTS) {
+            onError(new Error('Too many redirects.'));
+            return;
+        }
+        let parsed: URL;
+        try {
+            parsed = new URL(url);
+        } catch {
+            onError(new Error(`Invalid URL: ${url}`));
+            return;
+        }
+        if (parsed.protocol !== 'https:') {
+            onError(new Error(`Refusing non-HTTPS URL: ${url}`));
+            return;
+        }
+        if (!isAllowedHost(parsed.hostname)) {
+            onError(new Error(`Refusing to contact untrusted host: ${parsed.hostname}`));
+            return;
+        }
+        const req = https.get(url, {
+            headers: {
+                'User-Agent': 'jpipe-vscode',
+                'Accept': 'application/vnd.github+json',
+            },
+        }, onResponse);
+        req.on('error', onError);
+    }
+
+    /** Resolve a possibly-relative redirect Location against the request URL. */
+    private resolveRedirect(from: string, location: string): string {
+        try {
+            return new URL(location, from).toString();
+        } catch {
+            return location;
+        }
+    }
+}

--- a/packages/extension/src/extension/image-generation/release-manager.ts
+++ b/packages/extension/src/extension/image-generation/release-manager.ts
@@ -6,8 +6,8 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { JpipeLogger } from '../logger.js';
 
-/** GitHub repository that publishes the jPipe compiler releases. */
-const RELEASE_REPO = 'jpipe-mcscert/jpipe-compiler';
+/** Default GitHub repository that publishes the jPipe compiler releases. */
+const DEFAULT_RELEASE_REPO = 'jpipe-mcscert/jpipe-compiler';
 
 /** Only 2.x+ releases expose the `process` / `diagnostic` / `--headless doctor` subcommands
  *  the extension drives; older `jpipe.jar` releases predate them and are hidden. */
@@ -27,8 +27,8 @@ const ALLOWED_HOSTS = new Set([
 const KEY_INSTALLED = 'jpipe.managedCompiler';
 const KEY_LAST_CHECK = 'jpipe.managedCompiler.lastUpdateCheck';
 
-/** Only check for a newer release once per this window (ms). */
-const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+/** Fallback update-check interval (hours) when `jpipe.managedUpdateCheckIntervalHours` is unset. */
+const DEFAULT_UPDATE_INTERVAL_HOURS = 24;
 
 /** Follow at most this many HTTP redirects before giving up. */
 const MAX_REDIRECTS = 5;
@@ -91,9 +91,15 @@ export class ReleaseManager {
         private readonly logger: JpipeLogger
     ) {}
 
-    /** List installable (stable, v2.0.0+) releases, newest first. Throws on network/API failure. */
+    /**
+     * List installable releases (v2.0.0+ with a `jpipe-cli-*.jar` asset), newest first.
+     * Excludes pre-releases unless `jpipe.managedIncludePrereleases` is enabled; the rolling
+     * non-semver `unstable` tag is always excluded. Throws on network/API failure.
+     */
     public async listReleases(): Promise<JpipeRelease[]> {
-        const url = `https://api.github.com/repos/${RELEASE_REPO}/releases?per_page=100`;
+        const config = vscode.workspace.getConfiguration('jpipe');
+        const includePrereleases = config.get<boolean>('managedIncludePrereleases', false);
+        const url = `https://api.github.com/repos/${this.repo()}/releases?per_page=100`;
         const raw = await this.httpsGetJson(url);
         if (!Array.isArray(raw)) {
             throw new Error('Unexpected response from the GitHub releases API.');
@@ -101,7 +107,8 @@ export class ReleaseManager {
 
         const releases: JpipeRelease[] = [];
         for (const rel of raw as any[]) {
-            if (rel?.draft || rel?.prerelease) continue;
+            if (rel?.draft) continue;
+            if (rel?.prerelease && !includePrereleases) continue;
             const tag: string = rel?.tag_name ?? '';
             const semver = parseSemver(tag);
             if (!semver || semver[0] < MIN_MAJOR) continue;
@@ -182,8 +189,13 @@ export class ReleaseManager {
         const installed = this.getInstalled();
         if (!installed) return;
 
+        const config = vscode.workspace.getConfiguration('jpipe');
+        if (!config.get<boolean>('managedCheckForUpdates', true)) return;
+
+        const hours = config.get<number>('managedUpdateCheckIntervalHours', DEFAULT_UPDATE_INTERVAL_HOURS);
+        const intervalMs = (typeof hours === 'number' && hours > 0 ? hours : DEFAULT_UPDATE_INTERVAL_HOURS) * 3_600_000;
         const last = this.context.globalState.get<number>(KEY_LAST_CHECK, 0);
-        if (Date.now() - last < UPDATE_CHECK_INTERVAL_MS) return;
+        if (Date.now() - last < intervalMs) return;
         await this.context.globalState.update(KEY_LAST_CHECK, Date.now());
 
         try {
@@ -202,6 +214,12 @@ export class ReleaseManager {
     }
 
     // ---- internals -------------------------------------------------------
+
+    /** The `owner/repo` releases are pulled from (configurable for forks/testing). */
+    private repo(): string {
+        const configured = (vscode.workspace.getConfiguration('jpipe').get<string>('managedRepository', DEFAULT_RELEASE_REPO) ?? '').trim();
+        return configured || DEFAULT_RELEASE_REPO;
+    }
 
     private compilerRoot(): string {
         return path.join(this.context.globalStorageUri.fsPath, 'compiler');

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -63,8 +63,11 @@ export function activate(context: vscode.ExtensionContext): void {
             const picked = await vscode.window.showQuickPick(
                 releases.map((r, i) => ({
                     label: r.tag,
-                    description: [i === 0 ? '$(star-full) latest' : '', r.tag === installed?.tag ? '$(check) installed' : '']
-                        .filter(Boolean).join('  '),
+                    description: [
+                        formatReleaseDate(r.publishedAt),
+                        i === 0 ? '$(star-full) latest' : '',
+                        r.tag === installed?.tag ? '$(check) installed' : '',
+                    ].filter(Boolean).join('  ·  '),
                     detail: r.name,
                     release: r,
                 })),
@@ -173,6 +176,14 @@ export function deactivate(): Thenable<void> | undefined {
         return client.stop();
     }
     return undefined;
+}
+
+/** Format a release's ISO `published_at` as a short local date (e.g. "Jul 16, 2026"). */
+function formatReleaseDate(iso: string): string {
+    if (!iso) return '';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
 function resolveExcludedDirectories(): string[] {

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { LanguageClient, TransportKind, Trace, RevealOutputChannelOn } from 'vscode-languageclient/node.js';
 import { ImageGenerator, ImageFormat } from './image-generation/image-generator.js';
 import { PreviewProvider } from './image-generation/preview-provider.js';
+import { ReleaseManager, JpipeRelease } from './image-generation/release-manager.js';
 import { JpipeLogger } from './logger.js';
 
 let client: LanguageClient;
@@ -31,8 +32,71 @@ export function activate(context: vscode.ExtensionContext): void {
     );
 
     // Create image generator and preview provider (client passed for cursor→node highlighting)
-    const imageGenerator = new ImageGenerator(logger);
+    const releaseManager = new ReleaseManager(context, logger);
+    const imageGenerator = new ImageGenerator(logger, releaseManager);
     const previewProvider = new PreviewProvider(imageGenerator, client, context, logger);
+
+    /**
+     * Interactive flow: pick a release from GitHub, download its jar into hidden global
+     * storage, record it, and switch the extension into `managed` execution mode.
+     * `preselectTag` (from the update prompt) auto-selects that release when present.
+     */
+    async function installFromRelease(preselectTag?: string): Promise<void> {
+        let releases: JpipeRelease[];
+        try {
+            releases = await vscode.window.withProgress(
+                { location: vscode.ProgressLocation.Notification, title: 'jPipe: fetching available releases…' },
+                () => releaseManager.listReleases()
+            );
+        } catch (err: unknown) {
+            vscode.window.showErrorMessage(`jPipe: could not list releases. ${err instanceof Error ? err.message : String(err)}`);
+            return;
+        }
+        if (releases.length === 0) {
+            vscode.window.showWarningMessage('jPipe: no compatible releases (v2.0.0+) were found.');
+            return;
+        }
+
+        const installed = releaseManager.getInstalled();
+        let chosen = preselectTag ? releases.find(r => r.tag === preselectTag) : undefined;
+        if (!chosen) {
+            const picked = await vscode.window.showQuickPick(
+                releases.map((r, i) => ({
+                    label: r.tag,
+                    description: [i === 0 ? '$(star-full) latest' : '', r.tag === installed?.tag ? '$(check) installed' : '']
+                        .filter(Boolean).join('  '),
+                    detail: r.name,
+                    release: r,
+                })),
+                { title: 'Select a jPipe compiler release to install', placeHolder: 'Downloaded and run internally — no manual path needed' }
+            );
+            if (!picked) return;
+            chosen = picked.release;
+        }
+
+        try {
+            const jarPath = await vscode.window.withProgress(
+                { location: vscode.ProgressLocation.Notification, title: `jPipe: downloading ${chosen.tag}…`, cancellable: false },
+                (progress) => {
+                    let last = 0;
+                    return releaseManager.download(chosen!, (fraction) => {
+                        const pct = Math.round(fraction * 100);
+                        progress.report({ increment: pct - last, message: `${pct}%` });
+                        last = pct;
+                    });
+                }
+            );
+            await releaseManager.setInstalled(chosen.tag, jarPath);
+            await vscode.workspace.getConfiguration('jpipe').update('executionMode', 'managed', vscode.ConfigurationTarget.Global);
+            vscode.window.showInformationMessage(`jPipe ${chosen.tag} installed and activated (managed mode).`);
+            logger.info(`Managed jPipe compiler set to ${chosen.tag} at ${jarPath}`);
+        } catch (err: unknown) {
+            vscode.window.showErrorMessage(`jPipe: download failed. ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    // Opportunistic, throttled "newer version available" check (managed mode only).
+    void releaseManager.maybeNotifyUpdate(installFromRelease);
 
     async function resolveExportContext(): Promise<{ doc: vscode.TextDocument | undefined; diagramName: string | undefined }> {
         const active = vscode.window.activeTextEditor?.document;
@@ -82,12 +146,15 @@ export function activate(context: vscode.ExtensionContext): void {
         }),
         vscode.commands.registerCommand('jpipe.checkInstallation', async () => {
             const { ok, message } = await imageGenerator.check();
+            const installed = releaseManager.getInstalled();
+            const detail = installed ? `Managed compiler: ${installed.tag}\n\n${message}` : message;
             if (ok) {
-                vscode.window.showInformationMessage('jPipe is accessible.', { modal: true, detail: message });
+                vscode.window.showInformationMessage('jPipe is accessible.', { modal: true, detail });
             } else {
-                vscode.window.showErrorMessage('Cannot access jPipe.', { modal: true, detail: message });
+                vscode.window.showErrorMessage('Cannot access jPipe.', { modal: true, detail });
             }
-        })
+        }),
+        vscode.commands.registerCommand('jpipe.installFromRelease', () => installFromRelease())
     );
 }
 

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -146,8 +146,17 @@ export function activate(context: vscode.ExtensionContext): void {
         }),
         vscode.commands.registerCommand('jpipe.checkInstallation', async () => {
             const { ok, message } = await imageGenerator.check();
+            const mode = vscode.workspace.getConfiguration('jpipe').get<string>('executionMode', 'cli');
             const installed = releaseManager.getInstalled();
-            const detail = installed ? `Managed compiler: ${installed.tag}\n\n${message}` : message;
+            let header: string;
+            if (mode === 'managed') {
+                header = `Access method: managed (GitHub Release${installed ? ` ${installed.tag}` : ' — none installed'})`;
+            } else if (mode === 'jar') {
+                header = 'Access method: jar';
+            } else {
+                header = 'Access method: cli';
+            }
+            const detail = `${header}\n\n${message}`;
             if (ok) {
                 vscode.window.showInformationMessage('jPipe is accessible.', { modal: true, detail });
             } else {

--- a/packages/extension/src/extension/main.ts
+++ b/packages/extension/src/extension/main.ts
@@ -166,7 +166,13 @@ export function activate(context: vscode.ExtensionContext): void {
                 vscode.window.showErrorMessage('Cannot access jPipe.', { modal: true, detail });
             }
         }),
-        vscode.commands.registerCommand('jpipe.installFromRelease', () => installFromRelease())
+        vscode.commands.registerCommand('jpipe.installFromRelease', () => installFromRelease()),
+        vscode.commands.registerCommand('jpipe.export', async () => {
+            const configured = vscode.workspace.getConfiguration('jpipe').get<string>('defaultExportFormat', 'SVG');
+            const format = (ImageFormat as Record<string, ImageFormat>)[configured] ?? ImageFormat.SVG;
+            const { doc, diagramName } = await resolveExportContext();
+            imageGenerator.generateAndSave(format, doc, diagramName);
+        })
     );
 }
 


### PR DESCRIPTION
This pull request adds a new "managed" compiler mode to the jPipe extension, allowing users to download and manage the jPipe compiler directly from GitHub Releases. It also reorganizes and expands the extension's configuration options, improves the handling of external tool paths, and adds new export features. The most important changes are summarized below.

**Managed Compiler Mode and Configuration Enhancements:**

* Added a new "managed" compiler mode, enabling users to download and update the jPipe compiler JAR directly from GitHub Releases via the new `jpipe.installFromRelease` command and related settings (`jpipe.managedCheckForUpdates`, etc.). This is especially helpful for Windows users and those who want an easy setup. (`packages/extension/README.md`, `packages/extension/package.json`, [[1]](diffhunk://#diff-3c74adcf7769b29ba3b97df98b9d563f87a588bf1b7fafc42560d380858e78baR23-R33) [[2]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fR155-R166) [[3]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fL218-R249) [[4]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fL251-R374)
* Refactored the image generator to support all three execution modes ("cli", "jar", "managed") and to resolve the correct compiler invocation based on user configuration, including improved error handling for missing or misconfigured compilers. (`packages/extension/src/extension/image-generation/image-generator.ts`, [[1]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26R8-R20) [[2]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L42-R111) [[3]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L76-R158) [[4]](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L146-R203)

**Advanced and User-Friendly Settings:**

* Introduced new configuration options for compiler timeout (`jpipe.compilerTimeout`), extra JVM arguments (`jpipe.jvmArgs`), and additional directories to prepend to `PATH` (`jpipe.extraPath`) for finding external interpreters. (`packages/extension/package.json`, [packages/extension/package.jsonL251-R374](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fL251-R374))
* Moved and grouped settings into themed sections ("Compiler", "Managed Compiler", "Export", "Validation", "Logging") for easier navigation and clarity. (`packages/extension/package.json`, [[1]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fL251-R374) [[2]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fL274-R397)

**Export and Usability Improvements:**

* Added a new command to export diagrams in the default format, with settings to control the format and whether to open the exported file automatically. (`packages/extension/package.json`, [[1]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fR155-R166) [[2]](diffhunk://#diff-f9bdbba6141a612d98a76edc7613b0df3418080f19a948e57d3a76bb7ca4f78fL251-R374)
* Improved the handling of the `PATH` environment variable to allow user configuration and ensure external tools (e.g., `python3`, `dot`) are found reliably. (`packages/extension/src/extension/image-generation/image-generator.ts`, [packages/extension/src/extension/image-generation/image-generator.tsL23-R40](diffhunk://#diff-f5c13f236c931c1acae6d4486940031bc1eb566ff96378bd0ff525fd62065f26L23-R40))

These changes make the extension more robust, flexible, and user-friendly, especially for users who want a simpler setup or need to customize their environment.

Closes #13.
